### PR TITLE
Read the shipping version from its one source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "fuigo-pager-bin"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,8 +12,25 @@ downloads only the one matching the host's `os`/`cpu`, so a user pulls one
 
 ## The version has exactly one source
 
-`crates/codegen/fuigo-version/Cargo.toml` → `fuigo_version::VERSION` → what
-`fuigo --version` prints. Everything else is **derived**:
+`crates/codegen/fuigo-version/Cargo.toml` is the one place the number is
+written. Three things derive from it, and all three are checked:
+
+| derivation | mechanism | what catches drift |
+|---|---|---|
+| `fuigo_version::VERSION` | that crate's own `CARGO_PKG_VERSION` | — |
+| the binary's `<version> (<commit>)` stamp | `fuigo-pager-bin/build.rs` reads the manifest above | `the_stamped_version_is_the_one_source_of_truth` |
+| the seven npm packages | `sync-version.js` | `npm run check-version`, `prepublishOnly` |
+
+**This section used to claim the same thing while it was false.** `build.rs`
+stamped `fuigo-pager-bin`'s *own* `CARGO_PKG_VERSION`, so the version lived in
+two manifests that had to be bumped together and nothing noticed when only one
+was. v1.0.2 was tagged and pushed with the binary reporting `1.0.1`; the CI
+smoke test caught it after the tag, which is the last place it could still be
+caught for free. `build.rs` now reads the manifest directly and panics if it
+cannot — there is no fallback, because a wrong version is not a degraded build,
+it is a build that lies about which one it is.
+
+To cut a version, edit `fuigo-version/Cargo.toml` and run `sync-version`:
 
 ```sh
 cd crates/codegen/fuigo-pager/npm/fuigo
@@ -34,9 +51,6 @@ Three guards now make that unpublishable:
 | `sync-version.js` refuses a non-`x.y.z` version | any run without `--allow-prerelease` |
 | `assemble-platform-packages.js` runs `--check` first | every assemble |
 | `prepublishOnly` runs `--check` | every `npm publish` |
-
-To cut a new version, edit `fuigo-version/Cargo.toml` and run `sync-version`.
-Nothing else.
 
 ---
 

--- a/crates/codegen/fuigo-pager-bin/Cargo.toml
+++ b/crates/codegen/fuigo-pager-bin/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "fuigo-pager-bin"
-version = "1.0.1"
+# NOT the version `fuigo --version` prints, and not what npm publishes. Both of
+# those come from fuigo-version/Cargo.toml, which build.rs reads directly. This
+# number exists because cargo requires one; it is kept in step only for tidiness,
+# and nothing breaks if it drifts.
+version = "1.0.2"
 edition.workspace = true
 license = "Apache-2.0"
 authors = ["Ferrox Labs"]

--- a/crates/codegen/fuigo-pager-bin/build.rs
+++ b/crates/codegen/fuigo-pager-bin/build.rs
@@ -13,6 +13,7 @@ fn git_stdout(args: &[&str]) -> Option<String> {
 
 fn main() {
     println!("cargo:rerun-if-env-changed=FUIGO_VERSION");
+    println!("cargo:rerun-if-changed={}", version_manifest().display());
 
     // Watch the git files that change on commit/checkout so the version stamp refreshes
     // Never emit a missing path: cargo treats it as always dirty and rebuilds this crate every build
@@ -31,9 +32,40 @@ fn main() {
         .filter(|s| s.len() == 12)
         .unwrap_or_else(|| "unknown".to_string());
 
-    let version = std::env::var("FUIGO_VERSION")
-        .or_else(|_| std::env::var("CARGO_PKG_VERSION"))
-        .unwrap_or_else(|_| "0.0.0".to_string());
+    // The version half of the stamp must be the SAME value `fuigo_version::VERSION`
+    // resolves to, or `fuigo --version` and every other reader disagree.
+    // `fuigo_version::VERSION` is `option_env!("FUIGO_VERSION")` falling back to
+    // fuigo-version's own `CARGO_PKG_VERSION`, so mirror exactly that -- reading
+    // the sibling manifest, NOT this crate's `CARGO_PKG_VERSION`.
+    //
+    // Using this crate's version is what shipped `1.0.1` from a tree whose single
+    // source of truth said `1.0.2`: two package versions that had to be bumped in
+    // lockstep, and nothing that noticed when only one was. There is now one.
+    let version = match std::env::var("FUIGO_VERSION") {
+        Ok(v) => v,
+        Err(_) => version_from_source_of_truth(),
+    };
 
     println!("cargo:rustc-env=VERSION_WITH_COMMIT={version} ({commit})");
+}
+
+/// Path to fuigo-version's manifest: the one place the shipping version is written.
+fn version_manifest() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../fuigo-version/Cargo.toml")
+}
+
+/// Reads `version` out of fuigo-version's `[package]` table.
+///
+/// Panics rather than falling back. A wrong version is not a degraded build, it
+/// is a build that lies about which one it is -- and the failure would surface
+/// as a published package, not as a red CI job.
+fn version_from_source_of_truth() -> String {
+    let manifest = version_manifest();
+    let text = std::fs::read_to_string(&manifest)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", manifest.display()));
+    text.lines()
+        .find_map(|line| line.strip_prefix("version = "))
+        .map(|v| v.trim().trim_matches('"').to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| panic!("no `version = \"...\"` line in {}", manifest.display()))
 }

--- a/crates/codegen/fuigo-pager-bin/src/main.rs
+++ b/crates/codegen/fuigo-pager-bin/src/main.rs
@@ -2787,6 +2787,28 @@ mod tests {
             assert!(output.ends_with(expected_suffix), "{output:?}");
         }
     }
+    /// The stamp must name the same version `fuigo_version::VERSION` does.
+    ///
+    /// The test above only checks the stamp against itself, which is true no
+    /// matter which version it carries -- it passed on a build that printed
+    /// `1.0.1` from a tree whose single source of truth said `1.0.2`, because
+    /// build.rs read this crate's `CARGO_PKG_VERSION` instead of that source.
+    /// CI caught it after the tag was already pushed. This catches it at
+    /// `cargo test`.
+    #[test]
+    fn the_stamped_version_is_the_one_source_of_truth() {
+        let stamp = env!("VERSION_WITH_COMMIT");
+        let (version, rest) = stamp
+            .split_once(' ')
+            .unwrap_or_else(|| panic!("stamp is not `<version> (<commit>)`: {stamp:?}"));
+        assert_eq!(
+            version,
+            fuigo_version::VERSION,
+            "build.rs stamped {version:?} but fuigo_version::VERSION is {:?}",
+            fuigo_version::VERSION
+        );
+        assert!(rest.starts_with('(') && rest.ends_with(')'), "{stamp:?}");
+    }
     #[test]
     fn version_flags_and_doctor_are_distinct_early_intents() {
         let version = PagerArgs::try_parse_from(["fuigo", "--version"]).unwrap();


### PR DESCRIPTION
`fuigo --version` printed 1.0.1 from a tree whose version file said 1.0.2. The
release smoke test caught it, but only after `v1.0.2` was tagged and pushed —
six runners were already building a binary that would have shipped to npm as
1.0.2 while announcing itself as 1.0.1, to users, to the update checker, and to
every ACP client reading `service_version`.

## Cause

A duplicated fact. `RELEASE.md` said `fuigo-version/Cargo.toml` was the single
source and everything else derived from it, but `build.rs` stamped
`VERSION_WITH_COMMIT` from `fuigo-pager-bin`'s *own* `CARGO_PKG_VERSION`. Two
manifests had to be bumped in lockstep and nothing noticed when only one was.
The npm side was genuinely derived, so `check-version` stayed green throughout.

## Fix

`build.rs` reads `fuigo-version/Cargo.toml`, mirroring exactly what
`fuigo_version::VERSION` resolves to: `FUIGO_VERSION` when set, that manifest
otherwise. It **panics** if the file cannot be read or holds no version rather
than falling back — a wrong version is not a degraded build, it is a build that
lies about which one it is, and a fallback surfaces as a published package
instead of a red CI job.

The existing `version_output_writer_preserves_channel_aware_contract` compares
the stamp against itself, which is true whichever version it carries; that is
why it passed on the 1.0.1 build. The new
`the_stamped_version_is_the_one_source_of_truth` compares it against
`fuigo_version::VERSION`, so this drift fails at `cargo test` instead of after a
tag push.

`RELEASE.md` now lists all three derivations with the guard for each, and says
outright that the section previously asserted this while it was false.

## Verified

- binary reports `fuigo 1.0.2 (838b68cd7b60)` — the exact assertion CI failed on
- all 40 `fuigo-pager-bin` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)