### PR TITLE
Publish the Windows ARM binary under a name npm will accept

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,10 +359,19 @@ jobs:
       # and then tripped npm's spam detection on the fifth, leaving a state no
       # naive re-run could recover.
       #
-      # The sleep is for the same incident. Creating six similarly-named
-      # packages back-to-back is exactly the burst npm's name heuristic
-      # watches for; it flagged the fifth after four in ~30 seconds. Spacing
-      # them out costs two minutes on a release that already takes an hour.
+      # The burst theory that first justified the sleep was WRONG, and the
+      # correction is worth keeping: npm's filter is name-based, not rate-based.
+      # Publishing `fuigo-win32-arm64` ALONE, ten minutes after a successful
+      # sibling publish from the same account, fails identically. The token
+      # `win32-arm64` in an unscoped name is what it refuses -- which is why
+      # that one platform publishes as `fuigo-windows-arm64` (see the case
+      # statement below and bin/postinstall.js). The sleep stays because it is
+      # cheap, not because it was ever the fix.
+      #
+      # The loop no longer aborts on the first failure. When the 403 hit
+      # win32-arm64 at v1.0.2 it killed the step before win32-x64 was ever
+      # attempted, so ONE refused name cost TWO missing packages and the
+      # release had to be finished by hand.
       - name: Publish platform packages
         if: github.event_name == 'push' || inputs.dry_run == false
         working-directory: crates/codegen/fuigo-pager/npm
@@ -370,19 +379,36 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ steps.v.outputs.version }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
+          failed=""
           first=1
           for p in darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-arm64 win32-x64; do
-            name="fuigo-$p"
+            # The DIRECTORY is always fuigo-<platform>; the published NAME is not.
+            dir="fuigo-$p"
+            case "$p" in
+              win32-arm64) name="fuigo-windows-arm64" ;;
+              *)           name="fuigo-$p" ;;
+            esac
             if npm view "$name@$VERSION" version >/dev/null 2>&1; then
               echo "--- $name@$VERSION already published, skipping"
               continue
             fi
             [ "$first" = 1 ] || sleep 20
             first=0
-            echo "--- publishing $name@$VERSION"
-            (cd "$name" && npm publish --access public)
+            echo "--- publishing $name@$VERSION (from $dir)"
+            if ! (cd "$dir" && npm publish --access public); then
+              echo "::error::failed to publish $name@$VERSION"
+              failed="$failed $name"
+            fi
           done
+          # Fail AFTER trying all six, so one refused name cannot hide the rest.
+          # The meta package step is skipped by this failure on purpose: its
+          # optionalDependencies pin exact versions, so it must not ship while
+          # any platform package is missing.
+          if [ -n "$failed" ]; then
+            echo "::error::platform packages failed to publish:$failed"
+            exit 1
+          fi
 
       # Guarded the same way, so a re-run after a partial publish is safe.
       # This one must not go early: its optionalDependencies pin exact

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "fuigo-pager-bin"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "fuigo-version"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "semver",
 ]

--- a/crates/codegen/fuigo-pager-bin/Cargo.toml
+++ b/crates/codegen/fuigo-pager-bin/Cargo.toml
@@ -4,7 +4,7 @@ name = "fuigo-pager-bin"
 # those come from fuigo-version/Cargo.toml, which build.rs reads directly. This
 # number exists because cargo requires one; it is kept in step only for tidiness,
 # and nothing breaks if it drifts.
-version = "1.0.2"
+version = "1.0.3"
 edition.workspace = true
 license = "Apache-2.0"
 authors = ["Ferrox Labs"]

--- a/crates/codegen/fuigo-pager/npm/fuigo-darwin-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fuigo-darwin-arm64",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "darwin-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-darwin-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fuigo-darwin-x64",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "darwin-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-linux-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fuigo-linux-arm64",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "linux-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-linux-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fuigo-linux-x64",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "linux-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-win32-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "fuigo-win32-arm64",
-    "version": "1.0.2",
+    "name": "fuigo-windows-arm64",
+    "version": "1.0.3",
     "description": "win32-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-win32-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fuigo-win32-x64",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "win32-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo/bin/fuigo-bootstrap.js
+++ b/crates/codegen/fuigo-pager/npm/fuigo/bin/fuigo-bootstrap.js
@@ -31,10 +31,22 @@ function readLocalVersion() {
     try { return require('../package.json').version; } catch { return undefined; }
 }
 
+// npm's spam filter refuses to CREATE any unscoped package name containing the
+// token `win32-arm64`: 403 "Package name triggered spam detection". Measured,
+// not guessed -- `fuigo-win32-x64`, `fuigo-darwin-arm64` and `fuigo-linux-arm64`
+// all publish fine from the same account, and `fuigo-windows-arm64` with
+// identical os/cpu metadata published minutes after `fuigo-win32-arm64` was
+// refused. So this one package's npm NAME cannot be derived from
+// process.platform/process.arch, and every place that derives it needs this map.
+const PLATFORM_PACKAGE_OVERRIDES = {
+    'win32-arm64': 'fuigo-windows-arm64',
+};
+const platformPackageName = (k) => PLATFORM_PACKAGE_OVERRIDES[k] ?? `fuigo-${k}`;
+
 // Returns null when npm skipped the matching optional dependency
 // (unsupported platform, or --no-optional).
 function resolvePlatformPackageDir() {
-    const platformPkg = `fuigo-${process.platform}-${process.arch}`;
+    const platformPkg = platformPackageName(`${process.platform}-${process.arch}`);
     try {
         return path.dirname(require.resolve(`${platformPkg}/package.json`));
     } catch {
@@ -108,7 +120,7 @@ function resolveBinary() {
     const platformDir = resolvePlatformPackageDir();
     if (!platformDir) {
         console.error(`${pkgName}: no platform binary installed for ${process.platform}-${process.arch}.`);
-        console.error(`  Expected sibling package fuigo-${process.platform}-${process.arch}.`);
+        console.error(`  Expected sibling package ${platformPackageName(`${process.platform}-${process.arch}`)}.`);
         console.error(`  This usually means npm skipped optionalDependencies (e.g. --no-optional)`);
         console.error(`  or the platform is not supported.`);
         process.exit(1);

--- a/crates/codegen/fuigo-pager/npm/fuigo/bin/postinstall.js
+++ b/crates/codegen/fuigo-pager/npm/fuigo/bin/postinstall.js
@@ -40,12 +40,24 @@ if (!SUPPORTED.has(key)) {
     process.exit(0);
 }
 
+// npm's spam filter refuses to CREATE any unscoped package name containing the
+// token `win32-arm64`: 403 "Package name triggered spam detection". Measured,
+// not guessed -- `fuigo-win32-x64`, `fuigo-darwin-arm64` and `fuigo-linux-arm64`
+// all publish fine from the same account, and `fuigo-windows-arm64` with
+// identical os/cpu metadata published minutes after `fuigo-win32-arm64` was
+// refused. So this one package's npm NAME cannot be derived from
+// process.platform/process.arch, and every place that derives it needs this map.
+const PLATFORM_PACKAGE_OVERRIDES = {
+    'win32-arm64': 'fuigo-windows-arm64',
+};
+const platformPackageName = (k) => PLATFORM_PACKAGE_OVERRIDES[k] ?? `fuigo-${k}`;
+
 // Resolve the per-platform sibling package's directory. The matching
 // optionalDependency is installed by npm based on `os`/`cpu` filters; the
 // other five are silently skipped. If the matching one is missing, npm was
 // likely invoked with --no-optional or the platform is unsupported.
 function resolvePlatformPackageDir() {
-    const platformPkg = `fuigo-${key}`;
+    const platformPkg = platformPackageName(key);
     try {
         return path.dirname(require.resolve(`${platformPkg}/package.json`));
     } catch {
@@ -180,7 +192,7 @@ function cleanupOldVersions(binName) {
 
 const platformDir = resolvePlatformPackageDir();
 if (!platformDir) {
-    console.error(`fuigo: platform package fuigo-${key} not installed.`);
+    console.error(`fuigo: platform package ${platformPackageName(key)} not installed.`);
     console.error('  This usually means npm was invoked with --no-optional, or the install failed.');
     console.error('  Try: npm install -g fuigo');
     process.exit(0);

--- a/crates/codegen/fuigo-pager/npm/fuigo/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fuigo",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Bring Fuigo into your terminal",
     "license": "Apache-2.0",
     "bin": {
@@ -35,11 +35,11 @@
         "@iarna/toml": "^3.0.0"
     },
     "optionalDependencies": {
-        "fuigo-darwin-arm64": "1.0.2",
-        "fuigo-darwin-x64": "1.0.2",
-        "fuigo-linux-arm64": "1.0.2",
-        "fuigo-linux-x64": "1.0.2",
-        "fuigo-win32-arm64": "1.0.2",
-        "fuigo-win32-x64": "1.0.2"
+        "fuigo-darwin-arm64": "1.0.3",
+        "fuigo-darwin-x64": "1.0.3",
+        "fuigo-linux-arm64": "1.0.3",
+        "fuigo-linux-x64": "1.0.3",
+        "fuigo-windows-arm64": "1.0.3",
+        "fuigo-win32-x64": "1.0.3"
     }
 }

--- a/crates/codegen/fuigo-pager/npm/fuigo/scripts/sync-version.js
+++ b/crates/codegen/fuigo-pager/npm/fuigo/scripts/sync-version.js
@@ -38,6 +38,14 @@ const PLATFORMS = [
     'win32-arm64', 'win32-x64',
 ];
 
+// The published NAME is not always `fuigo-<platform>`; see bin/postinstall.js
+// for the measured reason. The DIRECTORY keeps its `fuigo-<platform>` name --
+// only what npm sees differs.
+const PACKAGE_NAME_OVERRIDES = {
+    'win32-arm64': 'fuigo-windows-arm64',
+};
+const packageNameFor = (p) => PACKAGE_NAME_OVERRIDES[p] ?? `${PREFIX}-${p}`;
+
 // Unscoped. `fuigo` and the six `fuigo-<platform>` names are ours on npm;
 // the `@fuigo-official` scope this once used is not an org that exists.
 const PREFIX = 'fuigo';
@@ -98,10 +106,13 @@ function main() {
     note('meta version', meta.version, version);
     meta.version = version;
 
-    meta.optionalDependencies = meta.optionalDependencies || {};
+    // Rebuilt from scratch, not merged: a renamed package must not leave its
+    // old pin behind, or npm resolves a name that will never exist again.
+    const priorPins = meta.optionalDependencies || {};
+    meta.optionalDependencies = {};
     for (const p of PLATFORMS) {
-        const name = `${PREFIX}-${p}`;
-        note(`  pin ${name}`, meta.optionalDependencies[name], version);
+        const name = packageNameFor(p);
+        note(`  pin ${name}`, priorPins[name], version);
         meta.optionalDependencies[name] = version;
     }
     if (!check) writeJson(META_PKG, meta);

--- a/crates/codegen/fuigo-version/Cargo.toml
+++ b/crates/codegen/fuigo-version/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 license = "Apache-2.0"
 name = "fuigo-version"
-version = "1.0.2"
+version = "1.0.3"
 edition.workspace = true
 description = "Lockstepped fuigo CLI version."
 


### PR DESCRIPTION
npm's spam filter refuses to **create** any unscoped package whose name contains the token `win32-arm64` (403, "Package name triggered spam detection"). `fuigo-win32-arm64` has therefore never existed on npm at any version, and Windows ARM users have installed the meta package with no binary since 1.0.1.

Measured, not guessed — one account, minutes apart, identical `os`/`cpu`:

| name | result |
|---|---|
| `fuigo-win32-x64` | published |
| `fuigo-darwin-arm64`, `fuigo-linux-arm64` | published |
| `fuigo-win32-arm64` | 403 |
| `fuigo-windows-arm64` | published |

Publishing the refused name **alone**, ten minutes after a successful sibling publish, fails identically — ruling out rate limiting, burst publishing, CI, the token and the tarball.

## Changes

- The platform package name was computed from `process.platform`-`process.arch` in two places, and `process.platform` is always `win32`, never `windows`. It now goes through an override map in `postinstall.js`, `fuigo-bootstrap.js` and `sync-version.js`. The **directory** keeps its `fuigo-<platform>` name; only npm sees the difference.
- `sync-version` rebuilds `optionalDependencies` instead of merging, so a renamed package cannot leave its old pin behind pointing at a name that will never exist.
- The publish loop no longer aborts on first failure. The 403 at v1.0.2 killed the step before `win32-x64` was attempted, so one refused name cost two missing packages. It now tries all six, reports each failure, and fails after — still blocking the meta package, whose pins are exact.
- Corrected the comment claiming the inter-publish sleep guarded against a burst heuristic. The filter is name-based; the burst theory was wrong.

Ships as 1.0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)