### PR TITLE
Scope every platform package under @fuigo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,12 +383,9 @@ jobs:
           failed=""
           first=1
           for p in darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-arm64 win32-x64; do
-            # The DIRECTORY is always fuigo-<platform>; the published NAME is not.
+            # The DIRECTORY is always fuigo-<platform>; the published NAME is scoped.
             dir="fuigo-$p"
-            case "$p" in
-              win32-arm64) name="fuigo-windows-arm64" ;;
-              *)           name="fuigo-$p" ;;
-            esac
+            name="@fuigo/$p"
             if npm view "$name@$VERSION" version >/dev/null 2>&1; then
               echo "--- $name@$VERSION already published, skipping"
               continue
@@ -409,6 +406,36 @@ jobs:
             echo "::error::platform packages failed to publish:$failed"
             exit 1
           fi
+
+      # WAIT FOR THE SIX TO BE RESOLVABLE BEFORE SHIPPING THE META PACKAGE.
+      # `npm publish` printing `+ name@version` does NOT mean the package is in
+      # the registry: a scoped first publish to a new org went to npm's Staged
+      # Packages and returned 404 to both anonymous and authenticated GETs for
+      # the better part of an hour. The meta package pins exact versions, so
+      # publishing it against names that do not resolve yet is the same broken
+      # install we just spent a release fixing. Poll until every one answers.
+      - name: Wait until every platform package resolves
+        if: github.event_name == 'push' || inputs.dry_run == false
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          set -uo pipefail
+          for p in darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-arm64 win32-x64; do
+            name="@fuigo/$p"
+            ok=0
+            for attempt in $(seq 1 60); do
+              if npm view "$name@$VERSION" version >/dev/null 2>&1; then
+                echo "--- $name@$VERSION resolves"; ok=1; break
+              fi
+              sleep 10
+            done
+            if [ "$ok" = 0 ]; then
+              echo "::error::$name@$VERSION did not become resolvable within 10 minutes."
+              echo "::error::It may be sitting in npm Staged Packages awaiting promotion."
+              exit 1
+            fi
+          done
 
       # Guarded the same way, so a re-run after a partial publish is safe.
       # This one must not go early: its optionalDependencies pin exact

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "fuigo-pager-bin"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "fuigo-version"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "semver",
 ]

--- a/crates/codegen/fuigo-pager-bin/Cargo.toml
+++ b/crates/codegen/fuigo-pager-bin/Cargo.toml
@@ -4,7 +4,7 @@ name = "fuigo-pager-bin"
 # those come from fuigo-version/Cargo.toml, which build.rs reads directly. This
 # number exists because cargo requires one; it is kept in step only for tidiness,
 # and nothing breaks if it drifts.
-version = "1.0.3"
+version = "1.0.4"
 edition.workspace = true
 license = "Apache-2.0"
 authors = ["Ferrox Labs"]

--- a/crates/codegen/fuigo-pager/npm/fuigo-darwin-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "fuigo-darwin-arm64",
-    "version": "1.0.3",
+    "name": "@fuigo/darwin-arm64",
+    "version": "1.0.4",
     "description": "darwin-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-darwin-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "fuigo-darwin-x64",
-    "version": "1.0.3",
+    "name": "@fuigo/darwin-x64",
+    "version": "1.0.4",
     "description": "darwin-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-linux-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "fuigo-linux-arm64",
-    "version": "1.0.3",
+    "name": "@fuigo/linux-arm64",
+    "version": "1.0.4",
     "description": "linux-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-linux-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "fuigo-linux-x64",
-    "version": "1.0.3",
+    "name": "@fuigo/linux-x64",
+    "version": "1.0.4",
     "description": "linux-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-win32-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "fuigo-windows-arm64",
-    "version": "1.0.3",
+    "name": "@fuigo/win32-arm64",
+    "version": "1.0.4",
     "description": "win32-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-win32-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "fuigo-win32-x64",
-    "version": "1.0.3",
+    "name": "@fuigo/win32-x64",
+    "version": "1.0.4",
     "description": "win32-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo/bin/fuigo-bootstrap.js
+++ b/crates/codegen/fuigo-pager/npm/fuigo/bin/fuigo-bootstrap.js
@@ -31,17 +31,20 @@ function readLocalVersion() {
     try { return require('../package.json').version; } catch { return undefined; }
 }
 
-// npm's spam filter refuses to CREATE any unscoped package name containing the
-// token `win32-arm64`: 403 "Package name triggered spam detection". Measured,
-// not guessed -- `fuigo-win32-x64`, `fuigo-darwin-arm64` and `fuigo-linux-arm64`
-// all publish fine from the same account, and `fuigo-windows-arm64` with
-// identical os/cpu metadata published minutes after `fuigo-win32-arm64` was
-// refused. So this one package's npm NAME cannot be derived from
-// process.platform/process.arch, and every place that derives it needs this map.
-const PLATFORM_PACKAGE_OVERRIDES = {
-    'win32-arm64': 'fuigo-windows-arm64',
-};
-const platformPackageName = (k) => PLATFORM_PACKAGE_OVERRIDES[k] ?? `fuigo-${k}`;
+// The platform packages are scoped under the `fuigo` npm org: @fuigo/<platform>-<arch>.
+// The meta package stays unscoped -- it is the name users install, and this is
+// the same split @next, @anthropic-ai and @vscode use for native sidecars.
+//
+// Scoping is not cosmetic. npm's spam filter refuses to CREATE an unscoped
+// package name containing the token `win32-arm64` (403 "Package name triggered
+// spam detection"), which is why fuigo-win32-arm64 never existed at any version
+// and Windows ARM shipped without a binary until 1.0.3. Measured: the refused
+// name fails even when published ALONE ten minutes after a successful sibling,
+// while the same binary under a different name publishes fine. A scope removes
+// that entire class of failure for every platform, not just the one that hit it.
+//
+// The DIRECTORY is still fuigo-<platform>-<arch>; only the npm name is scoped.
+const platformPackageName = (k) => `@fuigo/${k}`;
 
 // Returns null when npm skipped the matching optional dependency
 // (unsupported platform, or --no-optional).

--- a/crates/codegen/fuigo-pager/npm/fuigo/bin/postinstall.js
+++ b/crates/codegen/fuigo-pager/npm/fuigo/bin/postinstall.js
@@ -40,17 +40,20 @@ if (!SUPPORTED.has(key)) {
     process.exit(0);
 }
 
-// npm's spam filter refuses to CREATE any unscoped package name containing the
-// token `win32-arm64`: 403 "Package name triggered spam detection". Measured,
-// not guessed -- `fuigo-win32-x64`, `fuigo-darwin-arm64` and `fuigo-linux-arm64`
-// all publish fine from the same account, and `fuigo-windows-arm64` with
-// identical os/cpu metadata published minutes after `fuigo-win32-arm64` was
-// refused. So this one package's npm NAME cannot be derived from
-// process.platform/process.arch, and every place that derives it needs this map.
-const PLATFORM_PACKAGE_OVERRIDES = {
-    'win32-arm64': 'fuigo-windows-arm64',
-};
-const platformPackageName = (k) => PLATFORM_PACKAGE_OVERRIDES[k] ?? `fuigo-${k}`;
+// The platform packages are scoped under the `fuigo` npm org: @fuigo/<platform>-<arch>.
+// The meta package stays unscoped -- it is the name users install, and this is
+// the same split @next, @anthropic-ai and @vscode use for native sidecars.
+//
+// Scoping is not cosmetic. npm's spam filter refuses to CREATE an unscoped
+// package name containing the token `win32-arm64` (403 "Package name triggered
+// spam detection"), which is why fuigo-win32-arm64 never existed at any version
+// and Windows ARM shipped without a binary until 1.0.3. Measured: the refused
+// name fails even when published ALONE ten minutes after a successful sibling,
+// while the same binary under a different name publishes fine. A scope removes
+// that entire class of failure for every platform, not just the one that hit it.
+//
+// The DIRECTORY is still fuigo-<platform>-<arch>; only the npm name is scoped.
+const platformPackageName = (k) => `@fuigo/${k}`;
 
 // Resolve the per-platform sibling package's directory. The matching
 // optionalDependency is installed by npm based on `os`/`cpu` filters; the

--- a/crates/codegen/fuigo-pager/npm/fuigo/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fuigo",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Bring Fuigo into your terminal",
     "license": "Apache-2.0",
     "bin": {
@@ -35,11 +35,11 @@
         "@iarna/toml": "^3.0.0"
     },
     "optionalDependencies": {
-        "fuigo-darwin-arm64": "1.0.3",
-        "fuigo-darwin-x64": "1.0.3",
-        "fuigo-linux-arm64": "1.0.3",
-        "fuigo-linux-x64": "1.0.3",
-        "fuigo-windows-arm64": "1.0.3",
-        "fuigo-win32-x64": "1.0.3"
+        "@fuigo/darwin-arm64": "1.0.4",
+        "@fuigo/darwin-x64": "1.0.4",
+        "@fuigo/linux-arm64": "1.0.4",
+        "@fuigo/linux-x64": "1.0.4",
+        "@fuigo/win32-arm64": "1.0.4",
+        "@fuigo/win32-x64": "1.0.4"
     }
 }

--- a/crates/codegen/fuigo-pager/npm/fuigo/scripts/sync-version.js
+++ b/crates/codegen/fuigo-pager/npm/fuigo/scripts/sync-version.js
@@ -38,13 +38,10 @@ const PLATFORMS = [
     'win32-arm64', 'win32-x64',
 ];
 
-// The published NAME is not always `fuigo-<platform>`; see bin/postinstall.js
-// for the measured reason. The DIRECTORY keeps its `fuigo-<platform>` name --
-// only what npm sees differs.
-const PACKAGE_NAME_OVERRIDES = {
-    'win32-arm64': 'fuigo-windows-arm64',
-};
-const packageNameFor = (p) => PACKAGE_NAME_OVERRIDES[p] ?? `${PREFIX}-${p}`;
+// Platform packages publish scoped: @fuigo/<platform>-<arch>. The meta package
+// stays unscoped. See bin/postinstall.js for why the scope is load-bearing.
+// The DIRECTORY stays fuigo-<platform>-<arch>; only the npm name is scoped.
+const packageNameFor = (p) => `@fuigo/${p}`;
 
 // Unscoped. `fuigo` and the six `fuigo-<platform>` names are ours on npm;
 // the `@fuigo-official` scope this once used is not an org that exists.

--- a/crates/codegen/fuigo-version/Cargo.toml
+++ b/crates/codegen/fuigo-version/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 license = "Apache-2.0"
 name = "fuigo-version"
-version = "1.0.3"
+version = "1.0.4"
 edition.workspace = true
 description = "Lockstepped fuigo CLI version."
 


### PR DESCRIPTION
The six platform packages now publish as `@fuigo/<platform>-<arch>`. The meta package stays unscoped — it is the name users install, and this is the split `@next`, `@anthropic-ai` and `@vscode` use for native sidecars.

## Why

1.0.3 shipped five packages named `fuigo-<platform>` and one named `fuigo-windows-arm64`, because npm's spam filter refuses to **create** an unscoped name containing the token `win32-arm64`. That was a workaround for one platform, and it left the naming incoherent — five of one shape, one of another, with nothing in the name explaining why.

A scope removes the whole class of failure rather than the one instance of it. No future platform can be blocked by a name heuristic. `@fuigo/win32-arm64@1.0.2` is already live, published while diagnosing this, so the scope is proven to work.

## Also: a gate the last release needed and did not have

The workflow now waits until all six platform packages actually **resolve** before publishing the meta package.

`npm publish` printing `+ name@version` does not mean the package is in the registry — a scoped first publish to a new org sat in npm's Staged Packages and returned 404 to both anonymous and authenticated GETs for the better part of an hour. The meta package pins exact versions, so shipping it against names that do not resolve is the broken install this release exists to fix.

The unscoped packages remain published and are not removed; 1.0.4 simply stops referring to them.

Ships as 1.0.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)