### PR TITLE
Stop dialling xAI, and document the ACP entry point

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "fuigo-pager-bin"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "fuigo-version"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "semver",
 ]

--- a/crates/codegen/fuigo-pager-bin/Cargo.toml
+++ b/crates/codegen/fuigo-pager-bin/Cargo.toml
@@ -4,7 +4,7 @@ name = "fuigo-pager-bin"
 # those come from fuigo-version/Cargo.toml, which build.rs reads directly. This
 # number exists because cargo requires one; it is kept in step only for tidiness,
 # and nothing breaks if it drifts.
-version = "1.0.4"
+version = "1.0.5"
 edition.workspace = true
 license = "Apache-2.0"
 authors = ["Ferrox Labs"]

--- a/crates/codegen/fuigo-pager/npm/fuigo-darwin-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/darwin-arm64",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "darwin-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-darwin-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/darwin-x64",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "darwin-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-linux-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/linux-arm64",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "linux-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-linux-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/linux-x64",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "linux-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-win32-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/win32-arm64",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "win32-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-win32-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/win32-x64",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "win32-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo/README.md
+++ b/crates/codegen/fuigo-pager/npm/fuigo/README.md
@@ -2,19 +2,13 @@
 
 Bring Fuigo into your terminal. Fast, flicker-free CLI built for plans, subagents, and parallel work.
 
-**[Homepage](https://x.ai/cli)** | **[Documentation](https://docs.x.ai/build/overview)**
-
 ## Install
-
-```bash
-curl -fsSL https://x.ai/cli/install.sh | bash
-```
-
-Or install with npm:
 
 ```bash
 npm i -g fuigo
 ```
+
+npm downloads only the binary matching your platform, not all six.
 
 ## Get Started
 
@@ -26,7 +20,7 @@ fuigo
 fuigo -p "Explain this codebase"
 ```
 
-On first launch, Fuigo opens your browser to authenticate. For CI or headless environments, use an API key from [console.x.ai](https://console.x.ai):
+On first launch, Fuigo helps you set up a provider. For CI or headless environments, set an API key directly:
 
 ```bash
 export FUIGO_API_KEY="fuigo-..."
@@ -48,13 +42,15 @@ npm i -g fuigo@latest
 
 | Platform | Architecture |
 |---|---|
-| macOS | Apple Silicon (arm64) |
+| macOS | Apple Silicon (arm64), Intel (x86_64) |
 | Linux | x86_64, arm64 |
-| Windows | x86_64 |
+| Windows | x86_64, arm64 |
 
 ## Documentation
 
-For full documentation including configuration, MCP servers, custom models, headless mode, agent mode, and more, visit [docs.x.ai/build/overview](https://docs.x.ai/build/overview).
+Fuigo ships its own documentation. Run `/docs` inside the TUI, or read the
+extracted copy under `~/.fuigo/docs/user-guide/`, covering configuration, MCP
+servers, custom models, headless mode and agent mode.
 
 ## Feedback
 

--- a/crates/codegen/fuigo-pager/npm/fuigo/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fuigo",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "Bring Fuigo into your terminal",
     "license": "Apache-2.0",
     "bin": {
@@ -35,11 +35,11 @@
         "@iarna/toml": "^3.0.0"
     },
     "optionalDependencies": {
-        "@fuigo/darwin-arm64": "1.0.4",
-        "@fuigo/darwin-x64": "1.0.4",
-        "@fuigo/linux-arm64": "1.0.4",
-        "@fuigo/linux-x64": "1.0.4",
-        "@fuigo/win32-arm64": "1.0.4",
-        "@fuigo/win32-x64": "1.0.4"
+        "@fuigo/darwin-arm64": "1.0.5",
+        "@fuigo/darwin-x64": "1.0.5",
+        "@fuigo/linux-arm64": "1.0.5",
+        "@fuigo/linux-x64": "1.0.5",
+        "@fuigo/win32-arm64": "1.0.5",
+        "@fuigo/win32-x64": "1.0.5"
     }
 }

--- a/crates/codegen/fuigo-pager/src/headless/ext_protocol.rs
+++ b/crates/codegen/fuigo-pager/src/headless/ext_protocol.rs
@@ -275,7 +275,7 @@ fn decode_session_notification(method: &str, params: &str) -> ExtEvent {
             tracing::warn!(
                 method,
                 error = %e,
-                "headless: malformed x.ai session notification; ignoring"
+                "headless: malformed Fuigo session notification; ignoring"
             );
             return ExtEvent::None;
         }

--- a/crates/codegen/fuigo-pager/src/views/extensions_modal.rs
+++ b/crates/codegen/fuigo-pager/src/views/extensions_modal.rs
@@ -4495,7 +4495,7 @@ mod tests {
         assert!(
             rows.labels
                 .iter()
-                .any(|l| l.starts_with("Managed by grok.com")),
+                .any(|l| l.starts_with("Managed by Fuigo")),
             "managed section header must appear"
         );
         assert!(

--- a/crates/codegen/fuigo-pager/src/views/mcps_modal.rs
+++ b/crates/codegen/fuigo-pager/src/views/mcps_modal.rs
@@ -44,10 +44,10 @@ pub fn section_key(section: &McpSectionId) -> String {
     }
 }
 
-/// Display label for a section header, e.g. `"Managed by grok.com (3)"`.
+/// Display label for a section header, e.g. `"Managed by Fuigo (3)"`.
 pub fn section_label(section: &McpSectionId, count: usize) -> String {
     match section {
-        McpSectionId::Managed => format!("Managed by grok.com ({count})"),
+        McpSectionId::Managed => format!("Managed by Fuigo ({count})"),
         McpSectionId::Plugin(name) => format!("Plugin: {name} ({count})"),
         McpSectionId::Local => format!("Local ({count})"),
     }

--- a/crates/codegen/fuigo-shell-base/src/env.rs
+++ b/crates/codegen/fuigo-shell-base/src/env.rs
@@ -12,8 +12,22 @@ pub use fuigo_env::{
     FuigoBuildEnvironment, PROD_ASSET_SERVER_URL, PROD_CLI_CHAT_PROXY_BASE_URL,
     PROD_GATEWAY_WS_URL, PROD_RELAY_WS_URL, PROD_WS_ORIGIN,
 };
-/// Public Computer Hub WebSocket URL used by the local-workspace supervisor (`workspace_server --hub-url`) when `agent_config.hub.url` is unset.
-pub const PROD_COMPUTER_HUB_WS_URL: &str = "wss://computer-hub.grok.com/v1/tools";
+/// Computer Hub WebSocket URL used by the local-workspace supervisor when
+/// `agent_config.hub.url` is unset. **Empty: Fuigo operates no Computer Hub.**
+///
+/// This used to default to `wss://computer-hub.grok.com/v1/tools`, so a plain
+/// `fuigo workspace start` opened a websocket to xAI infrastructure. It escaped
+/// the sweep that emptied every other production endpoint in `fuigo_env`
+/// (whose own comment names this exact failure mode: "a default-on websocket to
+/// a host we do not control is the worst kind of leftover: it never appears in
+/// an HTTP client audit") — and it escaped it for that reason. The
+/// `fuigo-extra-ca` egress blocklist does NOT cover it: that guard is a reqwest
+/// DNS resolver, and this connection is raw tungstenite.
+///
+/// Empty means the feature is off until an operator sets `agent_config.hub.url`
+/// or passes `--hub-url`. Do not repoint it at FluxRouter: that is an inference
+/// gateway, not a tool hub.
+pub const PROD_COMPUTER_HUB_WS_URL: &str = "";
 #[cfg(any(test, feature = "test-support"))]
 pub use fuigo_env::EnvVarGuard;
 /// Env var that opts a process into gateway-bridge mode.

--- a/crates/codegen/fuigo-shell/src/agent/app.rs
+++ b/crates/codegen/fuigo-shell/src/agent/app.rs
@@ -318,7 +318,7 @@ pub async fn run_headless(
     crate::http::set_process_client_mode_headless();
     use crate::agent::relay::spawn_relay_connection_with_callback;
     use tokio_util::sync::CancellationToken;
-    const HEADLESS_NO_SESSION: &str = "Headless mode requires a grok.com session. \
+    const HEADLESS_NO_SESSION: &str = "Headless mode requires a Fuigo session. \
         Run `fuigo login` to sign in, or use `fuigo agent stdio` for API-key access.";
     fuigo_file_utils::queue::cleanup_orphaned_uploads(
         &fuigo_home::fuigo_home(),
@@ -647,7 +647,7 @@ impl DeferredRelayArm {
         ) else {
             return Some(self);
         };
-        info!("Relay-eligible auth token appeared after startup — arming grok.com relay");
+        info!("Relay-eligible auth token appeared after startup — arming Fuigo relay");
         spawn_leader_relay(
             self.slot,
             relay_config,
@@ -1034,7 +1034,7 @@ pub async fn run_leader(
                 );
             } else {
                 info!(
-                    "Relay not started: no grok.com session token \
+                    "Relay not started: no Fuigo session token \
                      (BYOK / local-only leader); will arm if an eligible \
                      token is hot-reloaded"
                 );

--- a/crates/codegen/fuigo-shell/src/agent/init.rs
+++ b/crates/codegen/fuigo-shell/src/agent/init.rs
@@ -179,7 +179,7 @@ fn resolve_config(
     }
     // A CLI/env-set Writeback still requires grok.com auth.
     if cfg.storage_mode == StorageMode::Writeback && !has_fuigo_auth {
-        tracing::info!("Writeback is disabled: requires auth with grok.com");
+        tracing::info!("Writeback is disabled: requires auth with Fuigo");
         cfg.storage_mode = StorageMode::Local;
     }
 

--- a/crates/codegen/fuigo-shell/src/agent/mvp_agent/acp_agent.rs
+++ b/crates/codegen/fuigo-shell/src/agent/mvp_agent/acp_agent.rs
@@ -334,7 +334,7 @@ impl acp::Agent for MvpAgent {
             tracing::info!(
                 label = ?login_label,
                 has_auth_provider,
-                "auth: advertising grok.com auth method",
+                "auth: advertising Fuigo auth method",
             );
         }
         let preferred_method = preferred_method_early;

--- a/crates/codegen/fuigo-shell/src/leader/server.rs
+++ b/crates/codegen/fuigo-shell/src/leader/server.rs
@@ -1047,10 +1047,35 @@ async fn handle_workspace_start(
     cancel: CancellationToken,
 ) -> Result<ControlPayload, ControlError> {
     let ws = &control_state.workspace;
+    // Cancellation outranks configuration. A caller that is shutting down gets
+    // told so; it does not need to hear that the hub is unconfigured.
+    //
+    // This used to happen by accident: the hub URL defaulted to a real xAI
+    // address, so it always parsed, and the first thing that actually noticed
+    // the token was the auth wait further down. With no default that ordering
+    // reversed and an aborted start reported a config error instead. Making the
+    // check explicit keeps the precedence a decision rather than a side effect.
+    if cancel.is_cancelled() {
+        return Err(workspace_err(
+            "leader is shutting down; cannot expose workspace to the hub",
+        ));
+    }
+    // PROD_COMPUTER_HUB_URL is empty by default (Fuigo runs no hub), so this can
+    // legitimately resolve to nothing. Say so plainly rather than letting an
+    // empty string reach `Url::parse` and surface as "relative URL without a base".
     let url_str = hub_url
         .filter(|u| !u.trim().is_empty())
         .or_else(|| ws.default_hub_url.clone())
-        .unwrap_or_else(|| PROD_COMPUTER_HUB_URL.to_string());
+        .or_else(|| {
+            let fallback = PROD_COMPUTER_HUB_URL.trim();
+            (!fallback.is_empty()).then(|| fallback.to_string())
+        })
+        .ok_or_else(|| {
+            workspace_err(
+                "no Computer Hub configured: set `hub.url` in the agent config or pass --hub-url"
+                    .to_string(),
+            )
+        })?;
     let url = url::Url::parse(&url_str)
         .map_err(|e| workspace_err(format!("invalid hub url {url_str}: {e}")))?;
     let cwd_path = PathBuf::from(&cwd);

--- a/crates/codegen/fuigo-shell/src/remote/chat_models_client.rs
+++ b/crates/codegen/fuigo-shell/src/remote/chat_models_client.rs
@@ -59,7 +59,7 @@ pub struct ListModesResponse {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ChatModelsError {
-    #[error("no grok.com credentials")]
+    #[error("no Fuigo credentials")]
     NoAuth,
     #[error("request timed out")]
     Timeout,

--- a/crates/codegen/fuigo-shell/src/remote/skills_client.rs
+++ b/crates/codegen/fuigo-shell/src/remote/skills_client.rs
@@ -265,7 +265,7 @@ fn product_skill_info(
 
 #[derive(Debug, thiserror::Error)]
 pub enum SkillsError {
-    #[error("no grok.com credentials")]
+    #[error("no Fuigo credentials")]
     NoAuth,
     #[error("network error: {0}")]
     Network(#[from] reqwest::Error),

--- a/crates/codegen/fuigo-update/src/auto_update.rs
+++ b/crates/codegen/fuigo-update/src/auto_update.rs
@@ -30,43 +30,36 @@ pub enum UpdateRunMode {
 const PROMPT_UPDATE_NOW: &str = "Update now? [Y/n/d]";
 const MSG_AUTO_UPDATE_BACKGROUND: &str = "Auto-update running in background.";
 const MSG_RUN_UPDATE_MANUAL: &str = "Run `fuigo update` to get the latest version.";
-/// An empty or `"stable"` channel means stable, the installers' default (`CHANNEL="${FUIGO_CHANNEL:-stable}"` in install.sh).
+/// An empty or `"stable"` channel means stable, which maps to the `@latest`
+/// npm dist-tag. (It also matches `CHANNEL="${FUIGO_CHANNEL:-stable}"` in the
+/// legacy bootstrap installers, which some existing installs still use.)
 fn is_stable_channel(channel: &str) -> bool {
     channel.is_empty() || channel == "stable"
 }
 
-/// Manual-install one-liner for this platform's bootstrap installer.
+/// Manual-install one-liner shown when auto-update cannot complete.
 ///
-/// On Unix the variable must prefix `bash` (which runs install.sh), not `curl`.
-/// In `VAR=x curl … | bash` the assignment applies to `curl` only and install.sh would fall back to stable.
+/// **npm, not a bootstrap script.** This used to print
+/// `curl -fsSL https://x.ai/cli/install.sh | bash` (and the PowerShell twin),
+/// which is xAI's installer for grok-build: following it would have replaced the
+/// user's Fuigo with a different product. Fuigo ships as the npm package `fuigo`
+/// plus six `@fuigo/<platform>` binaries, so npm is the real install path and the
+/// only one that yields Fuigo.
+///
+/// A release channel maps to an npm dist-tag. Stable (or an unset/unsafe value)
+/// means `@latest`.
 fn manual_install_cmd(channel: &str) -> String {
-    // Only interpolate a well-formed channel ([A-Za-z0-9._-]) into the shell one-liner
-    // Anything else falls back to stable (a working installer beats a broken quoted command)
+    // Only interpolate a well-formed channel ([A-Za-z0-9._-]) into the command.
+    // Anything else falls back to stable: a working install line beats a broken one.
     let channel = channel.trim();
     let safe = !channel.is_empty()
         && channel
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));
-    if channel == "enterprise" {
-        // Enterprise has its own bootstrap script; it needs no channel env.
-        return if cfg!(windows) {
-            "irm https://x.ai/cli/enterprise-install.ps1 | iex".to_string()
-        } else {
-            "curl -fsSL https://x.ai/cli/enterprise-install.sh | bash".to_string()
-        };
-    }
     if is_stable_channel(channel) || !safe {
-        return if cfg!(windows) {
-            "irm https://x.ai/cli/install.ps1 | iex".to_string()
-        } else {
-            "curl -fsSL https://x.ai/cli/install.sh | bash".to_string()
-        };
+        return "npm i -g fuigo@latest".to_string();
     }
-    if cfg!(windows) {
-        format!("$env:FUIGO_CHANNEL='{channel}'; irm https://x.ai/cli/install.ps1 | iex")
-    } else {
-        format!("curl -fsSL https://x.ai/cli/install.sh | FUIGO_CHANNEL='{channel}' bash")
-    }
+    format!("npm i -g fuigo@{channel}")
 }
 
 fn reinstall_hint(installer: &str, channel: &str) -> String {

--- a/crates/codegen/fuigo-update/src/auto_update_tests.rs
+++ b/crates/codegen/fuigo-update/src/auto_update_tests.rs
@@ -941,58 +941,49 @@ fn test_reinstall_hint_gh_release_mentions_gh_command() {
 
 #[test]
 fn test_reinstall_hint_internal_mentions_platform_installer() {
+    // These three tests used to pin the shape of a shell one-liner:
+    // `curl -fsSL https://x.ai/cli/install.sh | bash` / `irm … | iex`, that
+    // FUIGO_CHANNEL had to prefix `bash` and not `curl`, and that the enterprise
+    // channel used its own bootstrap script. All of that subtlety existed only
+    // because shell one-liners are fiddly -- and all of it pointed at xAI's
+    // installer, which installs grok-build, not Fuigo. Following that hint would
+    // have replaced the user's Fuigo with a different product.
+    //
+    // Fuigo ships as the npm package `fuigo` plus six `@fuigo/<platform>`
+    // binaries and nothing else, so npm is the only install path that yields
+    // Fuigo. A channel is an npm dist-tag; stable is `@latest`.
     let hint = reinstall_hint("internal", "stable");
-    if cfg!(windows) {
-        assert!(hint.contains("irm"), "should suggest irm install: {hint}");
-        assert!(
-            hint.contains("install.ps1"),
-            "should reference install.ps1: {hint}"
-        );
-        assert!(
-            !hint.contains("FUIGO_CHANNEL"),
-            "stable must not set channel: {hint}"
-        );
-    } else {
-        assert!(hint.contains("curl"), "should suggest curl install: {hint}");
-        assert!(
-            hint.contains("install.sh"),
-            "should reference install.sh: {hint}"
-        );
-        assert!(
-            !hint.contains("FUIGO_CHANNEL"),
-            "stable must not set channel: {hint}"
-        );
-    }
+    assert!(hint.contains("npm i -g fuigo@latest"), "{hint}");
+    assert!(
+        !hint.contains("x.ai") && !hint.contains("install.sh") && !hint.contains("install.ps1"),
+        "must not send a Fuigo user to xAI's installer: {hint}"
+    );
+    assert!(
+        !hint.contains("FUIGO_CHANNEL"),
+        "npm carries the channel in the tag, not an env var: {hint}"
+    );
 }
 
 #[test]
 fn test_reinstall_hint_internal_alpha_sets_channel() {
     let hint = reinstall_hint("internal", "alpha");
-    if cfg!(windows) {
-        assert!(
-            hint.contains("$env:FUIGO_CHANNEL='alpha'"),
-            "alpha should set FUIGO_CHANNEL: {hint}"
-        );
-    } else {
-        assert!(
-            hint.contains("| FUIGO_CHANNEL='alpha' bash"),
-            "alpha must set FUIGO_CHANNEL on bash (the process running \
-             install.sh), not curl: {hint}"
-        );
-    }
+    assert!(hint.contains("npm i -g fuigo@alpha"), "{hint}");
+    assert!(!hint.contains("FUIGO_CHANNEL"), "{hint}");
 }
 
 #[test]
-fn test_reinstall_hint_enterprise_uses_enterprise_script() {
-    // Enterprise ships via its own bootstrap script (channel hardcoded there), never install.sh with FUIGO_CHANNEL
+fn test_reinstall_hint_enterprise_uses_npm_like_every_other_channel() {
+    // Enterprise previously had its own bootstrap script. Fuigo publishes no
+    // enterprise artifact -- there is no Fuigo enterprise CDN, only npm -- so
+    // enterprise resolves to the `@enterprise` dist-tag like any other channel.
+    // NOTE FOR REVIEW: this presumes that dist-tag is actually published. If it
+    // is not, enterprise users get a 404 from npm instead of a wrong product;
+    // decide whether to publish the tag or fold enterprise into @latest.
     let hint = reinstall_hint("internal", "enterprise");
+    assert!(hint.contains("npm i -g fuigo@enterprise"), "{hint}");
     assert!(
-        hint.contains("/enterprise-install."),
-        "enterprise must use the published enterprise-install script: {hint}"
-    );
-    assert!(
-        !hint.contains("FUIGO_CHANNEL"),
-        "enterprise script needs no channel env: {hint}"
+        !hint.contains("enterprise-install."),
+        "must not point at xAI's enterprise bootstrap: {hint}"
     );
 }
 

--- a/crates/codegen/fuigo-version/Cargo.toml
+++ b/crates/codegen/fuigo-version/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 license = "Apache-2.0"
 name = "fuigo-version"
-version = "1.0.4"
+version = "1.0.5"
 edition.workspace = true
 description = "Lockstepped fuigo CLI version."
 


### PR DESCRIPTION
## ACP was never broken

A downstream integration spawned `fuigo acp stdio`, which fails to parse — there is no `acp` subcommand and never has been. It was copied from a stale comment in `run-fuigo.sh`.

**The entry point is:**
```
fuigo --permission-mode default agent stdio
```

Verified end to end **against the release binary**, real inference: initialize, authenticate, `session/new`, `session/prompt` → `end_turn`, camelCase token accounting, the 7 `session/update` kinds a client consumes, `set_model` across four models, bogus model rejected.

For integrators: 42–48 notifications go out under `_fuigo/*` and none are consumed by an ACP client — drop unrecognised ones rather than erroring.

## The Computer Hub default was live

`PROD_COMPUTER_HUB_WS_URL` was `wss://computer-hub.grok.com/v1/tools` and **reachable**: a plain `fuigo workspace start` opened a websocket to xAI.

It survived the sweep that emptied every other endpoint in `fuigo-env`, and for a specific reason — the `fuigo-extra-ca` blocklist is a **reqwest DNS resolver**, and this is raw tungstenite. The guard never covered it. `fuigo-env`'s own comment names the failure mode: *"a default-on websocket to a host we do not control is the worst kind of leftover: it never appears in an HTTP client audit."*

Cancellation now explicitly outranks the config check. It already did, but only because the hardcoded URL always parsed, so the auth wait was the first thing to notice a cancelled token.

## The update hint installed a different product

On update failure Fuigo printed `curl -fsSL https://x.ai/cli/install.sh | bash` — following it replaces Fuigo with grok-build. Now `npm i -g fuigo@latest`. The three tests that pinned the shell one-liner now assert npm **and** assert the absence of the xAI installer.

## Also

9 user-visible strings rebranded. The published npm README lost its x.ai links and a factual error: it claimed macOS arm64 + Windows x64 only, while we ship six platforms.

## Deliberately unchanged

`X-XAI-Token-Auth`/`xai-grok-cli` (~25 sites, one `obfstr!`-wrapped), `grok-cli:access` scope, `ai.x.grok` MDM domain, `LEGACY_SCOPE` (on-disk auth.json key), `GROK_OAUTH2_ISSUER`, `FUIGO_COM_METHOD_ID`. Each breaks something live — see HANDOFF-SESSION.md.

## Tests

| suite | result |
|---|---|
| `fuigo-pager --lib` | 9086 passed, 0 failed |
| `fuigo-shell --lib` | 6719 passed, 8 pre-existing |
| `fuigo-shell --lib agent::config` | 342 passed |
| `fuigo-update` | 122 passed, 10 pre-existing (new baseline) |

Every deviation from baseline was traced to a specific change and fixed; the pre-existing failures were proven by reverting and re-running.

Ships as 1.0.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)