### PR TITLE
Fuigo 1.0.11 candidate: token-efficient tool presentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "fuigo-version"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "semver",
 ]

--- a/crates/codegen/fuigo-pager/npm/fuigo-darwin-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/darwin-arm64",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "description": "darwin-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-darwin-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/darwin-x64",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "description": "darwin-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-linux-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/linux-arm64",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "description": "linux-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-linux-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/linux-x64",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "description": "linux-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-win32-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/win32-arm64",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "description": "win32-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-win32-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/win32-x64",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "description": "win32-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fuigo",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "description": "Bring Fuigo into your terminal",
     "license": "Apache-2.0",
     "bin": {
@@ -40,11 +40,11 @@
         "@iarna/toml": "^3.0.0"
     },
     "optionalDependencies": {
-        "@fuigo/darwin-arm64": "1.0.10",
-        "@fuigo/darwin-x64": "1.0.10",
-        "@fuigo/linux-arm64": "1.0.10",
-        "@fuigo/linux-x64": "1.0.10",
-        "@fuigo/win32-arm64": "1.0.10",
-        "@fuigo/win32-x64": "1.0.10"
+        "@fuigo/darwin-arm64": "1.0.11",
+        "@fuigo/darwin-x64": "1.0.11",
+        "@fuigo/linux-arm64": "1.0.11",
+        "@fuigo/linux-x64": "1.0.11",
+        "@fuigo/win32-arm64": "1.0.11",
+        "@fuigo/win32-x64": "1.0.11"
     }
 }

--- a/crates/codegen/fuigo-shell/src/session/acp_session_impl/sampler_turn.rs
+++ b/crates/codegen/fuigo-shell/src/session/acp_session_impl/sampler_turn.rs
@@ -333,11 +333,19 @@ impl SessionActor {
     /// Shared with `SnapshotToolDefinitions` so verbatim mirrors preserve the parent schema.
     pub(crate) fn turn_base_tool_specs(&self, defs: &[ToolDefinition]) -> Vec<ToolSpec> {
         let backend_search_active = self.backend_search_active();
-        defs.iter()
+        let tools = defs.iter()
             .filter(|td| !backend_search_active || td.function.name != "web_search")
             .cloned()
             .map(ToolSpec::from)
-            .collect()
+            .collect();
+        self.present_tool_specs(tools)
+    }
+
+    pub(crate) fn present_tool_specs(&self, mut tools: Vec<ToolSpec>) -> Vec<ToolSpec> {
+        crate::session::tool_presentation::present(
+            &mut tools, matches!(self.tool_metadata_snapshot.lock().unwrap().native_presentation.mode().as_str(), "compact" | "adaptive"),
+        );
+        tools
     }
 
     /// Hosted tools with overrides applied, plus the applied overrides to echo, in one pass.

--- a/crates/codegen/fuigo-shell/src/session/acp_session_impl/spawn.rs
+++ b/crates/codegen/fuigo-shell/src/session/acp_session_impl/spawn.rs
@@ -434,6 +434,7 @@ pub(crate) async fn spawn_session_actor(
         .count();
     let initial_conversation_len = conversation.len();
     let title_session_dir = crate::session::persistence::session_dir(&session_info);
+    let initial_native_presentation = crate::session::tool_presentation::NativePresentation::load(&title_session_dir);
     let title_refresh_watermark =
         crate::session::helpers::session_summary::load_title_refresh_watermark(&title_session_dir);
     let title_refresh_turns_at_spawn =
@@ -1816,7 +1817,10 @@ pub(crate) async fn spawn_session_actor(
         pending_classifier_completions: parking_lot::Mutex::new(VecDeque::new()),
         goal_classifier_in_flight: std::sync::atomic::AtomicBool::new(false),
         managed_mcp_handle,
-        tool_metadata_snapshot: Arc::new(std::sync::Mutex::new(Default::default())),
+        tool_metadata_snapshot: Arc::new(std::sync::Mutex::new(crate::session::tool_index::ToolMetadataSnapshot {
+            native_presentation: initial_native_presentation,
+            ..Default::default()
+        })),
         mcp_announcements: Mutex::new(
             persisted_announcement_state
                 .map(crate::session::announcement_state::McpAnnounced::from_persisted)

--- a/crates/codegen/fuigo-shell/src/session/acp_session_impl/tool_calls.rs
+++ b/crates/codegen/fuigo-shell/src/session/acp_session_impl/tool_calls.rs
@@ -494,7 +494,7 @@ impl SessionActor {
             super::refresh_classifier_transcript(&self.permissions, &conversation);
         }
         let mcp_surface_requested = tool_calls.iter().any(|c| {
-            c.function.name == "search_tool"
+            (c.function.name == "search_tool" && !crate::session::tool_presentation::native_search_arguments(&c.function.arguments))
                 || c.function.name == "use_tool"
                 || c.function
                     .name
@@ -588,7 +588,7 @@ impl SessionActor {
                 }
             }
         }
-        if approved.iter().any(|p| p.tool_name == "search_tool") {
+        if approved.iter().any(|p| p.tool_name == "search_tool" && p.parsed_args.get("scope").and_then(|v| v.as_str()) != Some("native")) {
             self.retry_auth_required_servers().await;
         }
         if mcp_surface_requested {
@@ -1005,7 +1005,7 @@ impl SessionActor {
                     }
                     let followups = bridge_result?;
                     deferred_followups.extend(followups);
-                    if prepared.tool_name == "search_tool" {
+                    if prepared.tool_name == "search_tool" && prepared.parsed_args.get("scope").and_then(|v| v.as_str()) != Some("native") {
                         let pi = self.chat_state_handle.get_prompt_index().await as i64;
                         self.last_search_prompt_index
                             .store(pi, std::sync::atomic::Ordering::Relaxed);

--- a/crates/codegen/fuigo-shell/src/session/acp_session_impl/turn.rs
+++ b/crates/codegen/fuigo-shell/src/session/acp_session_impl/turn.rs
@@ -2574,7 +2574,7 @@ impl SessionActor {
                         crate::agent::subagent::strip_ask_user_question_tool(&mut tools);
                         crate::agent::subagent::strip_workflow_tool(&mut tools);
                     }
-                    tools
+                    self.present_tool_specs(tools)
                 } else {
                     let tools = self.turn_base_tool_specs(&tool_definitions);
                     if self.startup_hints.is_subagent {
@@ -2673,6 +2673,32 @@ impl SessionActor {
                     parameters: schema,
                 });
             }
+            // Presentation is applied AFTER recall-only classification and all
+            // finalization/child restrictions. It cannot confer eligibility.
+            let adaptive = self.tool_metadata_snapshot.lock().unwrap().native_presentation.mode() == "adaptive";
+            let deferred_native: std::collections::BTreeMap<String, String> = if adaptive {
+                effective_tools.iter().filter(|tool| !self.delivery_tools.borrow().contains(&tool.name) && matches!(
+                    self.agent.borrow().tool_bridge().tool_kind(&tool.name),
+                    Some(ToolKind::ImageGen | ToolKind::VideoGen | ToolKind::ImageToVideo | ToolKind::ReferenceToVideo)
+                )).map(|tool| (tool.name.clone(), crate::session::tool_presentation::fingerprint(tool))).collect()
+            } else { Default::default() };
+            if adaptive {
+                let enabled = !finalize_response && effective_tools.iter().any(|tool| tool.name == "search_tool");
+                effective_tools = self.tool_metadata_snapshot.lock().unwrap().native_presentation.project(
+                    req_id, effective_tools, &deferred_native.keys().cloned().collect(), enabled,
+                );
+            }
+            let presentation_checkpoint = self.tool_metadata_snapshot.lock().unwrap().native_presentation.pending_checkpoint();
+            if let Some(hints) = presentation_checkpoint {
+                let (respond_to, receive) = tokio::sync::oneshot::channel();
+                self.notifications.persistence_tx.send(crate::session::persistence::PersistenceMsg::PresentationHints {
+                    hints: hints.clone(), respond_to,
+                }).map_err(|_| acp::Error::internal_error().data("Presentation persistence channel closed"))?;
+                receive.await.map_err(|_| acp::Error::internal_error().data("Presentation persistence acknowledgment lost"))?
+                    .map_err(|error| acp::Error::internal_error().data(format!("Presentation persistence failed: {error}")))?;
+                self.tool_metadata_snapshot.lock().unwrap().native_presentation.checkpoint_saved(hints);
+            }
+            let advertised_native: std::collections::BTreeSet<String> = effective_tools.iter().map(|t| t.name.clone()).collect();
             let build_req_start = std::time::Instant::now();
             let request = self
                 .chat_state_handle
@@ -3138,6 +3164,19 @@ impl SessionActor {
                 );
             }
             let mut tool_calls = response.tool_calls().to_vec();
+            if !deferred_native.is_empty() && tool_calls.iter().any(|call| deferred_native.contains_key(&call.name)) {
+                let current = self.present_tool_specs(self.prepare_tool_definitions().await.into_iter().map(ToolSpec::from).collect());
+                for call in &tool_calls {
+                    if let Some(expected) = deferred_native.get(&call.name) {
+                        if !advertised_native.contains(&call.name) {
+                            return Err(acp::Error::internal_error().data("Native tool was not advertised in this request; discover its schema with search_tool scope=native before calling it"));
+                        }
+                        if !current.iter().any(|tool| tool.name == call.name && crate::session::tool_presentation::fingerprint(tool) == *expected) {
+                            return Err(acp::Error::internal_error().data("Native tool schema changed during inference; refresh discovery before execution"));
+                        }
+                    }
+                }
+            }
             // An unadvertised action must never execute during the final-answer slot.
             if finalize_response
                 && tool_calls

--- a/crates/codegen/fuigo-shell/src/session/compact_tool_descriptions.json
+++ b/crates/codegen/fuigo-shell/src/session/compact_tool_descriptions.json
@@ -1,0 +1,580 @@
+[
+  {
+    "name": "run_terminal_command",
+    "original": "Run a bash command and return its output.\n\nUsage notes:\n  - You can specify an optional timeout in milliseconds (up to 36000000ms). If not specified, foreground commands exceeding the default timeout will be automatically backgrounded instead of killed. You will receive a task id to check output later. Background tasks are not bounded by the default: with timeout omitted or 0 they run until they exit or are killed; a positive timeout still applies.\n  - Timeout enforcement: when the timeout fires, the wrapper kills the child process group (SIGTERM, escalated to SIGKILL after a ~1s grace period). Descendants that did not detach via `setsid` / `nohup` will also be killed. `timeout: 0` in `background: true` mode disables the wrapper timeout entirely; the child's lifetime is owned by the model via kill_command_or_subagent.\n  - If the output exceeds 40000 characters, the middle is truncated (you keep the beginning and end) and the result includes the path to a log file with the full output, which you can read or search.\n  - You can use the background parameter to run the command in the background (e.g., dev servers, long builds): it returns a task id immediately and keeps running in the background. You are notified on completion, so do not poll or sleep-wait for it. You do not need to use '&' at the end of the command when using this parameter.",
+    "parameters": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "required": [
+        "command",
+        "description"
+      ],
+      "properties": {
+        "command": {
+          "description": "The bash command to run.",
+          "type": "string"
+        },
+        "timeout": {
+          "description": "Optional timeout in milliseconds (max 36000000). Default: 120000; foreground commands exceeding it are automatically backgrounded.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0,
+          "default": 120000,
+          "maximum": 36000000
+        },
+        "description": {
+          "description": "One sentence explanation as to why this command needs to be run and how it contributes to the goal.",
+          "type": "string"
+        },
+        "background": {
+          "description": "Set to true for long-running commands that should run in the background (e.g., dev servers, long builds). Returns a task id immediately while the command keeps running in the background; you are notified on completion, so do not poll or sleep-wait for it.",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "type": "object"
+    },
+    "compact": "Run bash; return output. Optional timeout_ms is at most 36000000. Foreground commands exceeding the default auto-background (not killed) and return a task ID. Background commands without a positive timeout run until exit or explicit kill; timeout 0 disables their wrapper timeout. On timeout, terminate the process group with SIGTERM then SIGKILL after ~1s; detached setsid/nohup descendants may survive. Output over 40000 characters retains beginning/end plus a full-log path. background=true returns immediately; completion notifies you—do not poll or sleep-wait, and do not append '&'."
+  },
+  {
+    "name": "read_file",
+    "original": "Read a file.\n\nUsage:\n- The target_file parameter can be a relative path in the workspace or an absolute path\n- By default, it reads up to 1000 lines starting from the beginning of the file\n- Line numbers (1-based) appear as anchors in the format LINE_NUMBER→LINE_CONTENT on the first returned line and on every 10th line of the file; the lines in between show content only. Count from the nearest anchor when referring to a specific line\n- This tool can read PDF files (.pdf), PowerPoint files (.pptx), Jupyter notebooks (.ipynb files), and image files (e.g. PNG, JPG, etc).\n- When reading an image file the contents are presented visually as this tool uses multimodal LLMs.",
+    "parameters": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "required": [
+        "target_file"
+      ],
+      "type": "object",
+      "properties": {
+        "target_file": {
+          "description": "The path of the file to read. You can use either a relative path in the workspace or an absolute path. If an absolute path is provided, it will be preserved as is.",
+          "type": "string"
+        },
+        "offset": {
+          "description": "The line number to start reading from. Only provide if the file is too large to read at once.",
+          "type": "integer",
+          "default": 1
+        },
+        "limit": {
+          "description": "The number of lines to read. Only provide if the file is too large to read at once.",
+          "type": "integer"
+        },
+        "pages": {
+          "description": "Page range for PDF files (e.g. '1-5', '3', '10-'). Required for PDFs with more than 10 pages. Max 20 pages per call. Ignored for non-PDF files.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
+          "description": "Output format for PDF files. 'image' (default) renders pages as images. 'text' extracts text content. Ignored for non-PDF files.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "compact": "Read a workspace-relative or absolute path; default first 1000 lines. Line anchors are 1-based LINE_NUMBER→LINE_CONTENT on the first returned line and every tenth file line; count intervening lines from the nearest anchor. Supports text, PDF, PowerPoint, notebooks and images; images are presented visually."
+  },
+  {
+    "name": "search_replace",
+    "original": "Replace an exact string in a file.\n\n- `read_file` prefixes each line with \"LINE_NUMBER→\". That prefix is not part of the file: match only what comes after the →, with its exact indentation.\n- `old_string` must match exactly one place in the file. If it appears more than once, add surrounding lines to make it unique, or set `replace_all` to change every occurrence (handy for renaming an identifier).\n- To create a new file, set `old_string` to an empty string.",
+    "parameters": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "required": [
+        "file_path",
+        "old_string",
+        "new_string"
+      ],
+      "properties": {
+        "file_path": {
+          "description": "The path to the file to modify. You can use either a relative path in the workspace or an absolute path.",
+          "type": "string"
+        },
+        "old_string": {
+          "description": "The text to replace",
+          "type": "string"
+        },
+        "new_string": {
+          "description": "The text to replace it with (must be different from old_string)",
+          "type": "string"
+        },
+        "replace_all": {
+          "description": "Replace all occurrences of old_string (default false)",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "type": "object"
+    },
+    "compact": "Replace an exact file string. Exclude read_file's LINE_NUMBER→ anchors; preserve indentation. old_string must uniquely match, unless replace_all=true; add surrounding context to disambiguate. Empty old_string creates a new file."
+  },
+  {
+    "name": "list_dir",
+    "original": "Lists files and directories in a given path.\nThe 'target_directory' parameter can be relative to the workspace root or absolute.\n\nOther details:\n    - The result does not display dot-files and dot-directories.\n    - Respects .gitignore patterns (files/directories ignored by git are not shown).\n    - Large directories are summarized with file counts and extension breakdowns instead of listing all files.",
+    "parameters": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "required": [
+        "target_directory"
+      ],
+      "type": "object",
+      "properties": {
+        "target_directory": {
+          "description": "Path to directory to list contents of, relative to the workspace root or absolute.",
+          "type": "string"
+        }
+      }
+    },
+    "compact": "List a workspace-relative or absolute directory. Hides dotfiles/directories and honors .gitignore. Large directories return counts and extension summaries instead of every entry."
+  },
+  {
+    "name": "grep",
+    "original": "Search file contents with regular expressions (ripgrep).\n\n- Full regex syntax, so escape literal special characters: `functionCall\\(`, or `interface\\{\\}` to find interface{} in Go.\n- Pass pattern as a raw regex string — no surrounding quotes.\n- Respects .gitignore unless you pass a broad glob like '--glob *'.\n- Only filter by 'type' or 'glob' when you are sure of the file type; import paths may not match source file types (.js vs .ts).\n- Output is ripgrep-style: ':' marks match lines, '-' marks context lines, grouped by file. Large results are capped and report \"at least\" counts.",
+    "parameters": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "required": [
+        "pattern"
+      ],
+      "type": "object",
+      "properties": {
+        "pattern": {
+          "description": "The regular expression pattern to search for in file contents (rg --regexp)",
+          "type": "string"
+        },
+        "path": {
+          "description": "File or directory to search in (rg pattern -- PATH). Defaults to workspace path.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "glob": {
+          "description": "Glob pattern (rg --glob GLOB -- PATH) to filter files (e.g. \"*.js\", \"*.{ts,tsx}\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "-B": {
+          "description": "Number of lines to show before each match (rg -B).",
+          "type": "integer"
+        },
+        "-A": {
+          "description": "Number of lines to show after each match (rg -A).",
+          "type": "integer"
+        },
+        "-C": {
+          "description": "Number of lines to show before and after each match (rg -C).",
+          "type": "integer"
+        },
+        "-i": {
+          "description": "Case insensitive search (rg -i).",
+          "type": "boolean",
+          "default": false
+        },
+        "type": {
+          "description": "File type to search (rg --type). Common types: js, py, rust, go, java, etc. More efficient than glob for standard file types.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "head_limit": {
+          "description": "Limit output to first N lines/entries, equivalent to \"| head -N\". Defaults to 200 lines or 500 entries.",
+          "type": "integer"
+        },
+        "multiline": {
+          "description": "Enable multiline mode where . matches newlines and patterns can span lines (rg -U --multiline-dotall).",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "compact": "Search contents with ripgrep regex. Supply raw regex without surrounding quotes; escape literal regex metacharacters. Honors .gitignore unless overridden by a broad glob such as '--glob *'. Filter type/glob only when certain (imports and source extensions may differ). ':' denotes matches, '-' context, grouped by file. Capped results report 'at least' counts."
+  },
+  {
+    "name": "get_command_or_subagent_output",
+    "original": "Get output and status from a background task, monitor, or subagent.\n\nUsage notes:\n- Pass task_ids with one or more ids from background=true commands or subagents (a monitor's task_id is returned by monitor); for a single task use a one-element array. Multiple ids with a positive timeout_ms wait until all complete\n- Omit timeout_ms or pass 0 for a non-blocking status snapshot; set a positive timeout_ms to wait up to that many milliseconds, capped at 600000 (~10 min)\n- Returns current output, status, and exit code if completed\n- If output is large, use read_file on the output_file path",
+    "parameters": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "task_ids": {
+          "description": "Task IDs to get output from. Pass one or more; for a single task use a one-element array. With a positive timeout_ms, multiple ids wait until all complete. Omit timeout_ms or pass 0 for a non-blocking snapshot.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "timeout_ms": {
+          "description": "Max wait time in milliseconds, up to 600000 (~10 min). A positive value waits for completion; omit or pass 0 for a non-blocking status poll.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0,
+          "default": null,
+          "maximum": 600000
+        }
+      },
+      "type": "object",
+      "required": []
+    },
+    "compact": "Get output, status and completed exit codes for task_ids from background commands, monitors or subagents. Use an array even for one ID. Omitted/zero timeout_ms is nonblocking; positive timeout waits for all IDs, capped at 600000ms. Read output_file for large output."
+  },
+  {
+    "name": "scheduler_create",
+    "original": "Create a scheduled task that runs a prompt on a recurring interval, or update an existing one in place.\n\nUse this tool when a user asks you to loop, repeat, or schedule a prompt or a task.\n\nSet fire_immediately: true to also fire once on creation; by default the first run waits for the interval.\n\nTo change an existing task, pass its task_id: provided fields replace old values, omitted ones are unchanged, and the schedule keeps its phase. An unknown id errors.\n\nUsage notes:\n- Interval format: \"5m\" (minutes), \"2h\" (hours), \"1d\" (days), \"60s\" (seconds, min 60)\n- Maximum 50 scheduled tasks at once\n- Tasks auto-expire after 7 days\n- For one-time delayed work, run a background terminal command (e.g. `sleep 1800 && <command>`) instead; its completion notifies you",
+    "parameters": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "task_id": {
+          "description": "Id of an existing task to update in place: provided fields replace old values, omitted ones are unchanged, the schedule keeps its phase, and an unknown id errors. Omit to create a task.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "interval": {
+          "description": "Interval between executions, e.g. \"5m\", \"2h\", \"1d\". Required to create; optional with task_id",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "prompt": {
+          "description": "The prompt text to execute on each scheduled fire. Required to create; optional with task_id",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "durable": {
+          "description": "Whether the task persists across sessions. Default: false. Create-only: ignored with task_id",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "foreground": {
+          "description": "Run each fire as a main-conversation turn instead of a background subagent; set true only when runs need the conversation's context. Default: false. Create-only: ignored with task_id",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "fire_immediately": {
+          "description": "Whether to fire immediately on creation (true) or wait for the first interval (false). Default: false. Create-only: ignored with task_id",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "type": "object",
+      "required": []
+    },
+    "compact": "Create/update a recurring prompt task when requested by the user. Intervals: 5m, 2h, 1d or seconds >=60; at most50 tasks, expiring after7 days. fire_immediately defaults false. With task_id, provided fields replace values, omitted fields and schedule phase persist; unknown IDs error. For one-time delayed work, use a background terminal command; completion notifies you."
+  },
+  {
+    "name": "monitor",
+    "original": "Start a background monitor that streams events from a long-running script. Each stdout line is an event - you can keep working and notifications arrive in the chat. Exit ends the watch.\n\n**Output volume**: Every stdout line is a main-agent wake. Print only `DONE`/`FAILED`/`CANCELLED`. No progress or CHANGE lines. Use `grep --line-buffered` in pipes (plain `grep` buffers and delays events by minutes).\n\n**Responsiveness**: Emit `FAILED` to notify immediately when any required item fails; never wait for unrelated work to finish. Include every tracked failure signal in this immediate failure condition.\n\nSet `persistent: true` for session-length watches (PR monitoring, log tails) -- the monitor runs until you call kill_command_or_subagent or until the session ends. Otherwise it stops at `timeout_ms` (default 10h).",
+    "parameters": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "required": [
+        "command",
+        "description"
+      ],
+      "type": "object",
+      "properties": {
+        "command": {
+          "description": "Shell command or script. Each stdout line is an event; exit ends the watch.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Short human-readable description of what you are monitoring (shown in every notification).",
+          "type": "string"
+        },
+        "timeout_ms": {
+          "description": "Kill the monitor after this deadline (ms). Default: 36000000 (10 hr). Max: 36000000 (10 hr).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0,
+          "default": 36000000
+        },
+        "persistent": {
+          "description": "Run for the lifetime of the session (no timeout). Stop with kill_command_or_subagent.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "compact": "Run a background event script; each stdout line wakes the agent, exit ends the watch. Emit only DONE/FAILED/CANCELLED—not progress/CHANGE. Notify FAILED immediately on any required tracked failure; do not wait for unrelated work. Use grep --line-buffered in pipes to avoid delayed events. persistent=true lasts until explicit kill or session end; otherwise timeout_ms applies (default10h)."
+  },
+  {
+    "name": "workflow",
+    "original": "Launch a workflow: a Rhai script that orchestrates subagents as one background run. Provide exactly one `source`: a registered workflow `name`, an inline `script`, a `script_path`, or a same-process `resume`. Optionally pass `args` (bound to the script's `args`) and `agent_budget`, an absolute cap on cumulative child-agent calls: every agent() and parallel() item consumes one slot (schema retries do not); default 128. The host also caps live children per run (32 by default, host-configured) — larger parallel() panels are queued and still act as a barrier. The call returns immediately; progress appears in `/workflow runs` and completion is reported automatically — do not poll or sleep-wait.\n\nPrefer a registered workflow when one fits; author a script for bounded fan-out over a known work list, staged research and verification, or several independent perspectives. Before writing or editing a script, read the `create-workflow` skill's SKILL.md. `validate_only: true` runs a path-specific smoke check (metadata, compile, one canned-host path) — not proof that every branch or live tool works.\n\nA started run gets a session-unique display name (e.g. `review-changes`, `review-changes-2`) — the handle to show the user and use with `/workflow pause|resume|stop <name>`; keep run IDs internal. Each launch persists an editable `script_path`; edit it and launch as a new run to iterate. Use the `resume` source only for a same-process paused run (process restarts are terminal); it reuses the run's original immutable source and args, and a budget-limited run resumes only with a higher `agent_budget`. Save reusable scripts to `.fuigo/workflows/<name>.rhai`.",
+    "parameters": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "required": [
+        "source"
+      ],
+      "type": "object",
+      "properties": {
+        "source": {
+          "description": "Exactly one workflow source. The `type` tag selects a registered name, inline script, script path, or same-process resume.",
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "Name of a registered workflow (built-in, or discovered from the project `.fuigo/workflows/` or user `~/.fuigo/workflows/`).",
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "const": "name"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "type",
+                "name"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "script": {
+                  "description": "Inline Rhai workflow script. It must start with a pure-literal `let meta = #{ name: ..., description: ... };` map. Before authoring, read the `create-workflow` skill's SKILL.md. Run the path-specific `validate_only` smoke check with representative args.",
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "const": "script"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "type",
+                "script"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "script_path": {
+                  "description": "Path to a .rhai workflow script on disk.",
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "const": "script_path"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "type",
+                "script_path"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "resume_from_run_id": {
+                  "description": "Resume a same-process paused run, continuing its original immutable source and args. A budget-limited run resumes only when `agent_budget` is passed with a higher cap. Process-restart interruptions are terminal.",
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "const": "resume"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "type",
+                "resume_from_run_id"
+              ]
+            }
+          ]
+        },
+        "agent_budget": {
+          "description": "Absolute cumulative cap on logical child-agent calls for this run. Every agent() and every parallel() item consumes one slot; schema retries do not. Defaults to 128 and may be set from 1 through 1,024. A panel that would exceed the remaining budget is rejected before any of its children launch.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1,
+          "maximum": 1024,
+          "default": null
+        },
+        "args": {
+          "description": "JSON value bound to the script's `args` global. Use an object for named arguments.",
+          "default": null
+        },
+        "validate_only": {
+          "description": "Run a path-specific smoke check without launching: validate metadata, compile the full script, and execute the single path selected by the supplied args and canned host results. It does not exercise every branch or prove live tools and agent outputs work.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "compact": "Run a Rhai workflow with exactly one source: registered name, inline script, script_path or same-process resume. args binds script args. agent_budget caps cumulative child calls (default128); each agent()/parallel item costs one slot, schema retries do not. Host concurrent cap defaults32; excess children queue and parallel remains a barrier. Returns immediately, completion notifies—do not poll/sleep-wait. Prefer a fitting registered workflow; read create-workflow/SKILL.md before writing scripts. validate_only proves metadata/compilation/one canned path, not all branches or live tools. Show the unique display name and use it with /workflow pause|resume|stop; keep run IDs internal. Each launch persists editable script_path; edits require a new run. Resume only same-process paused runs (restart is terminal), retaining immutable source/args; budget-limited resume requires a higher agent_budget. Save reusable scripts in .fuigo/workflows/<name>.rhai."
+  },
+  {
+    "name": "image_gen",
+    "original": "Generate a new image from a text description using Imagine; returns the saved image's absolute path. When telling the user where it was saved, refer to it by its short session-relative path (e.g. `images/1.jpg`) rather than the absolute path, so it renders as a clickable link that opens the image. To produce multiple images, emit multiple tool calls with distinct prompts.",
+    "parameters": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "required": [
+        "prompt"
+      ],
+      "type": "object",
+      "properties": {
+        "prompt": {
+          "description": "Text description of the image to generate.",
+          "type": "string"
+        },
+        "aspect_ratio": {
+          "description": "Aspect ratio of the generated image, decide it based on the user's request. Defaults to 'auto'. 1:1 for square (icons, profiles), 16:9 for wide (landscapes, cinematic), 9:16 for tall (phone wallpapers, stories), 3:2 for horizontal photos, 2:3 for vertical (portraits, posters).",
+          "type": "string",
+          "default": "auto"
+        }
+      }
+    },
+    "compact": "Generate a new image from text via Imagine. Returns absolute saved path; show users a short session-relative path (e.g. images/1.jpg) for clickable rendering. Multiple images require separate calls with distinct prompts."
+  },
+  {
+    "name": "image_edit",
+    "original": "Edit or transform existing image(s) via the Ferrox Labs Imagine API; use instead of image_gen for image-to-image work (preserve likeness, transfer style, remix). Returns the saved image's absolute path. When telling the user where it was saved, refer to it by its short session-relative path (e.g. `images/1.jpg`) rather than the absolute path, so it renders as a clickable link that opens the image. Each required `image` is one reference — a user-attachment token (e.g. \"[Image #1]\"), an absolute filesystem path, or a `data:image/...;base64,...` URL (see the `image` parameter for the resolution order and details).",
+    "parameters": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "required": [
+        "prompt",
+        "image"
+      ],
+      "type": "object",
+      "properties": {
+        "prompt": {
+          "description": "A text description of the desired edit or transformation. Describe what the output image should look like, referencing the input image(s).",
+          "type": "string"
+        },
+        "image": {
+          "description": "Reference image(s) to condition the edit on. Each is one reference, in priority order: (1) a user attachment — its placeholder token, e.g. \"[Image #1]\" (attachments have no path you can see, so never invent one); (2) an absolute filesystem path the user gave you; (3) a `data:image/...;base64,...` URL.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "aspect_ratio": {
+          "description": "The aspect ratio of the output image. For single-image edits this is ignored — the output matches the input image's aspect ratio. For multi-image edits, defaults to 'auto'. Supported values: 1:1, 16:9, 9:16, 4:3, 3:4, 3:2, 2:3, 2:1, 1:2, 19.5:9, 9:19.5, 20:9, 9:20, auto.",
+          "type": "string",
+          "default": "auto"
+        }
+      }
+    },
+    "compact": "Edit existing images via Ferrox Labs Imagine for likeness, style transfer or remix; use instead of image_gen for image-to-image work. Each image reference may be an attachment token, absolute path or data:image/...;base64 URL; see parameter resolution rules. Returns absolute path; display short session-relative paths (e.g. images/1.jpg)."
+  },
+  {
+    "name": "image_to_video",
+    "original": "Generate a video from a single source image; returns the saved video's absolute path. When telling the user where it was saved, refer to it by its short session-relative path (e.g. `videos/1.mp4`) rather than the absolute path, so it renders as a clickable link that opens the video. Provide `image` for the image to animate and optionally a `prompt` to guide the animation. Use this tool when the user provides an image and wants it animated, turned into a video, or used as the first frame. Example: image_to_video(image=\"/Users/me/photo.jpg\", prompt=\"gentle camera push-in with wind moving the hair\", duration=6, resolution_name=\"480p\")",
+    "parameters": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "required": [
+        "image"
+      ],
+      "type": "object",
+      "properties": {
+        "prompt": {
+          "description": "Optional prompt to guide the video generation model. If omitted, a natural animation applies automatically.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "image": {
+          "description": "Source image to animate. Provide an absolute filesystem path, HTTPS URL, or `data:image/...;base64,...` URL.",
+          "type": "string"
+        },
+        "duration": {
+          "description": "Duration of the video generation, either 6 or 10 seconds. Default to 6 unless the user requests longer.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "resolution_name": {
+          "description": "Resolution name of the video generation, only specify it when user asks for a specific resolution, either 480p or 720p. Defaults to 480p unless the user specifically requests for higher quality.",
+          "type": "string",
+          "default": "480p"
+        }
+      }
+    },
+    "compact": "Animate one source image or use it as a video's first frame. Supply image and optional motion prompt. Returns absolute video path; show users a short session-relative path such as videos/1.mp4."
+  },
+  {
+    "name": "reference_to_video",
+    "original": "Generate a video from reference images and/or preset voices, guided by a required text prompt; returns the saved video's absolute path. When telling the user where it was saved, refer to it by its short session-relative path (e.g. `videos/1.mp4`) rather than the absolute path, so it renders as a clickable link that opens the video. Provide up to 7 `images` (style/content references: people, objects, clothing, settings) and/or up to 3 `voices` (preset voice identifiers the subjects speak in); at least one of either is required. Tag references in the prompt as `<IMAGE_0>`, `<IMAGE_1>`, ... and `<AUDIO_0>`, `<AUDIO_1>`, ... Use this tool when the user wants a video referencing existing images without locking the first frame, or wants a speaking subject with a specific voice. Example: reference_to_video(prompt=\"The person from <IMAGE_0> presents the product from <IMAGE_1>, speaking with the voice from <AUDIO_0>\", images=[\"/Users/me/host.jpg\", \"/Users/me/product.jpg\"], voices=[\"eve\"], aspect_ratio=\"16:9\", duration=10, resolution_name=\"480p\")",
+    "parameters": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "required": [
+        "prompt",
+        "aspect_ratio"
+      ],
+      "type": "object",
+      "properties": {
+        "prompt": {
+          "description": "Prompt to guide the video generation model. Describe the desired video.",
+          "type": "string"
+        },
+        "images": {
+          "description": "Reference images, up to 7 entries; the images are used as style/content references for the generated video (people, objects, clothing, settings). Each entry may be an absolute filesystem path, HTTPS URL, or `data:image/...;base64,...` URL. Reference them in the prompt as `<IMAGE_0>`, `<IMAGE_1>`, ... May be empty when `voices` is provided.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "voices": {
+          "description": "Optional preset voices the subject(s) speak in, up to 3 entries, each a voice identifier from the built-in roster (e.g. \"ara\", \"eve\", \"leo\", \"rex\"; same voices as the Ferrox Labs text-to-speech API; an unknown identifier fails with the list of available voices). Reference them in the prompt as `<AUDIO_0>`, `<AUDIO_1>`, `<AUDIO_2>`. Usable alongside `images` or on their own.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "aspect_ratio": {
+          "description": "Aspect ratio of the generated video, decide it based on the user's request. 1:1 for square (icons, profiles), 16:9 for wide (landscapes, cinematic), 9:16 for tall (phone wallpapers, stories), 4:3 or 3:2 for horizontal photos, 3:4 or 2:3 for vertical (portraits, posters).",
+          "type": "string"
+        },
+        "duration": {
+          "description": "Duration of the video in seconds, between 1 and 15. Defaults to 6.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "resolution_name": {
+          "description": "Resolution name of the video generation, only specify it when user asks for a specific resolution, either 480p or 720p. Defaults to 480p.",
+          "type": "string",
+          "default": "480p"
+        }
+      }
+    },
+    "compact": "Generate video from reference images/preset voices and a required prompt, without locking the first frame. At most7 images and3 voices; at least one image or voice required. Reference them as <IMAGE_0>, <IMAGE_1>, ... and <AUDIO_0>, <AUDIO_1>, ... in the prompt. Use for referenced people/style/content or a specified speaking voice. Returns absolute path; display a short session-relative path (videos/1.mp4)."
+  }
+]

--- a/crates/codegen/fuigo-shell/src/session/mod.rs
+++ b/crates/codegen/fuigo-shell/src/session/mod.rs
@@ -465,6 +465,7 @@ pub(crate) mod memory_observation;
 pub(crate) mod normalize_cache;
 pub mod persistence;
 pub mod execution_state;
+pub(crate) mod tool_presentation;
 pub use fuigo_shared::placeholder_images;
 pub mod plan_mode;
 pub mod prompt_history;

--- a/crates/codegen/fuigo-shell/src/session/persistence.rs
+++ b/crates/codegen/fuigo-shell/src/session/persistence.rs
@@ -208,6 +208,10 @@ pub struct SessionStateCopy {
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum PersistenceMsg {
+    PresentationHints {
+        hints: crate::session::tool_presentation::PresentationHints,
+        respond_to: tokio::sync::oneshot::Sender<io::Result<()>>,
+    },
     ExecutionState {
         mutation: crate::session::execution_state::ExecutionMutation,
         respond_to: tokio::sync::oneshot::Sender<io::Result<crate::session::execution_state::Snapshot>>,
@@ -1845,6 +1849,10 @@ impl SessionPersistence {
                 spawn_worktree_touch(&self.info);
             }
             match msg {
+                PersistenceMsg::PresentationHints { hints, respond_to } => {
+                    let result = crate::session::tool_presentation::persist_hints(&session_dir(&self.info), &hints).await;
+                    let _ = respond_to.send(result);
+                }
                 PersistenceMsg::UpgradeToWriteback { auth_manager } => {
                     self.upgrade_to_writeback(auth_manager).await;
                 }

--- a/crates/codegen/fuigo-shell/src/session/tool_index.rs
+++ b/crates/codegen/fuigo-shell/src/session/tool_index.rs
@@ -112,6 +112,7 @@ pub(crate) struct ServerMetadata {
 /// Updated when MCP tools are registered or re-initialized.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ToolMetadataSnapshot {
+    pub native_presentation: crate::session::tool_presentation::NativePresentation,
     pub tools: Vec<ToolMetadata>,
     pub servers: Vec<ServerMetadata>,
     pub mcp_initialized: bool,
@@ -133,6 +134,9 @@ impl Bm25ToolSearchIndex {
 }
 
 impl ToolSearchIndex for Bm25ToolSearchIndex {
+    fn discover_native(&self, query: &str, limit: usize) -> serde_json::Value {
+        self.snapshot.lock().unwrap().native_presentation.discover(query, limit)
+    }
     fn search_snapshot(&self, query: &str, limit: usize) -> SearchSnapshot {
         let snapshot = self.snapshot.lock().unwrap().clone();
 

--- a/crates/codegen/fuigo-shell/src/session/tool_index_tests.rs
+++ b/crates/codegen/fuigo-shell/src/session/tool_index_tests.rs
@@ -9,6 +9,7 @@ fn make_snapshot_with_servers(
     servers: Vec<ServerMetadata>,
 ) -> Arc<Mutex<ToolMetadataSnapshot>> {
     Arc::new(Mutex::new(ToolMetadataSnapshot {
+        native_presentation: Default::default(),
         tools,
         servers,
         mcp_initialized: true,
@@ -288,6 +289,7 @@ fn local_mcp_tool_indexing_still_uses_qualified_name() {
 #[test]
 fn gateway_only_snapshot_can_stay_partial() {
     let index = Bm25ToolSearchIndex::new(Arc::new(Mutex::new(ToolMetadataSnapshot {
+        native_presentation: Default::default(),
         tools: vec![ToolMetadata {
             qualified_name: "grafana__search_dashboards".into(),
             server_name: "grafana".into(),

--- a/crates/codegen/fuigo-shell/src/session/tool_presentation.rs
+++ b/crates/codegen/fuigo-shell/src/session/tool_presentation.rs
@@ -1,0 +1,319 @@
+//! Opt-in presentation only. Never remove tools, alter schemas or modify registry.
+use fuigo_sampling_types::ToolSpec;
+use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
+
+#[derive(Deserialize)]
+struct Entry {
+    name: String,
+    original: String,
+    parameters: serde_json::Value,
+    compact: String,
+}
+
+fn catalog() -> &'static [Entry] {
+    static CATALOG: OnceLock<Vec<Entry>> = OnceLock::new();
+    CATALOG.get_or_init(|| {
+        serde_json::from_str(include_str!("compact_tool_descriptions.json"))
+            .expect("checked built-in description catalog")
+    })
+}
+
+pub(crate) fn native_search_arguments(arguments: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(arguments).ok()
+        .is_some_and(|v| v.get("scope").and_then(|v| v.as_str()) == Some("native"))
+}
+
+pub(crate) fn fingerprint(tool: &ToolSpec) -> String {
+    blake3::hash(&serde_json::to_vec(tool).expect("serializable tool spec")).to_hex().to_string()
+}
+
+/// Session-owned presentation hints, not permission state. Reconciled with the
+/// currently eligible projection for EVERY request. No cross-session globals.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct NativePresentation {
+    task: String,
+    catalog: Vec<ToolSpec>,
+    selected: std::collections::BTreeMap<String, String>,
+    full: bool,
+    enabled: bool,
+    restored: bool,
+    mode: Option<String>,
+    checkpoint: Option<PresentationHints>,
+}
+
+/// Bounded, untrusted presentation hints. Never persisted authority.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PresentationHints {
+    mode: String,
+    selected: std::collections::BTreeMap<String, String>,
+}
+
+const HINTS_FILE: &str = "tool-presentation.json";
+
+pub(crate) async fn persist_hints(dir: &std::path::Path, hints: &PresentationHints) -> std::io::Result<()> {
+    crate::session::storage::write_bytes_atomic_async(
+        &dir.join(HINTS_FILE), serde_json::to_vec(hints).map_err(std::io::Error::other)?,
+    ).await
+}
+
+impl NativePresentation {
+    pub(crate) fn load(dir: &std::path::Path) -> Self {
+        use std::io::Read;
+        let result = (|| -> std::io::Result<PresentationHints> {
+            let file = std::fs::File::open(dir.join(HINTS_FILE))?;
+            let mut bytes = Vec::new();
+            file.take(8193).read_to_end(&mut bytes)?;
+            if bytes.len() > 8192 { return Err(std::io::Error::other("presentation hints oversized")); }
+            let hints: PresentationHints = serde_json::from_slice(&bytes).map_err(std::io::Error::other)?;
+            if !matches!(hints.mode.as_str(), "full" | "compact" | "adaptive") || hints.selected.len() > 8
+                || hints.selected.iter().any(|(name, hash)| name.len() > 256 || hash.len() != 64 || !hash.bytes().all(|c| c.is_ascii_hexdigit())) {
+                return Err(std::io::Error::other("invalid presentation hints"));
+            }
+            Ok(hints)
+        })();
+        match result {
+            Ok(hints) => Self { selected: hints.selected.clone(), mode: Some(hints.mode.clone()), restored: true, checkpoint: Some(hints), ..Default::default() },
+            Err(error) => {
+                if error.kind() != std::io::ErrorKind::NotFound { tracing::warn!(%error, "Ignoring invalid presentation hints; using configured default"); }
+                Self::default()
+            }
+        }
+    }
+
+    pub(crate) fn mode(&self) -> String {
+        // Explicit host configuration, including full/unknown, overrides saved hints.
+        std::env::var("FUIGO_TOOL_PRESENTATION").ok().or_else(|| self.mode.clone()).unwrap_or_else(|| "full".into())
+    }
+
+    pub(crate) fn pending_checkpoint(&self) -> Option<PresentationHints> {
+        let mode = self.mode();
+        if self.checkpoint.is_none() && !matches!(mode.as_str(), "compact" | "adaptive") { return None; }
+        let hints = PresentationHints {
+            mode: if matches!(mode.as_str(), "compact" | "adaptive") { mode } else { "full".into() },
+            selected: self.selected.iter().take(8).map(|(k,v)| (k.clone(),v.clone())).collect(),
+        };
+        (self.checkpoint.as_ref() != Some(&hints)).then_some(hints)
+    }
+
+    pub(crate) fn checkpoint_saved(&mut self, hints: PresentationHints) { self.checkpoint = Some(hints); }
+
+    pub(crate) fn project(
+        &mut self, task: &str, tools: Vec<ToolSpec>,
+        deferred: &std::collections::BTreeSet<String>, enabled: bool,
+    ) -> Vec<ToolSpec> {
+        if self.task != task {
+            self.task = task.to_owned();
+            if !self.restored { self.selected.clear(); }
+            self.restored = false;
+            self.full = false;
+        }
+        self.enabled = enabled;
+        self.catalog = tools.iter().filter(|t| deferred.contains(&t.name)).cloned().collect();
+        self.selected.retain(|name, hash| self.catalog.iter().any(|t| &t.name == name && fingerprint(t) == *hash));
+        if !enabled { return tools; }
+        let hidden: Vec<_> = self.catalog.iter().filter(|t| !self.selected.contains_key(&t.name)).map(|t| t.name.clone()).collect();
+        let mut visible: Vec<_> = tools.into_iter().filter(|t| self.full || !deferred.contains(&t.name) || self.selected.contains_key(&t.name)).collect();
+        if let Some(search) = visible.iter_mut().find(|t| t.name == "search_tool") {
+            let base = search.description.get_or_insert_with(String::new);
+            if !hidden.is_empty() && !self.full {
+                base.push_str(" Native media tools are available via scope=native: ");
+                // Names come only from eligible native registry, never descriptions
+                // from external servers. Keep the discovery hint bounded.
+                base.push_str(&hidden.iter().take(16).cloned().collect::<Vec<_>>().join(", "));
+                base.push_str(". Search reveals schemas for the next request; call native tools directly, never through use_tool. Discovery is not approval.");
+            }
+        }
+        visible
+    }
+
+    pub(crate) fn discover(&mut self, query: &str, limit: usize) -> serde_json::Value {
+        if !self.enabled {
+            return serde_json::json!({"results": [], "available": false, "note": "Native activation unavailable in current execution state"});
+        }
+        if query.len() > 256 || query.trim().is_empty() || limit == 0 {
+            return serde_json::json!({"results": [], "note": "Use a nonempty query of at most256 bytes and positive limit"});
+        }
+        let query = query.to_lowercase();
+        let words: Vec<_> = query.split(|c: char| !c.is_alphanumeric()).filter(|w| !w.is_empty()).collect();
+        let mut candidates: Vec<_> = self.catalog.iter().filter_map(|tool| {
+            let text = format!("{} {}", tool.name, tool.description.as_deref().unwrap_or("")).to_lowercase();
+            let score = if tool.name.eq_ignore_ascii_case(query.trim()) { usize::MAX }
+                else { words.iter().filter(|word| text.contains(**word)).count() };
+            (score > 0).then_some((score, tool))
+        }).collect();
+        candidates.sort_by(|a,b| b.0.cmp(&a.0).then_with(|| a.1.name.cmp(&b.1.name)));
+        let mut results = Vec::new();
+        for (_,tool) in candidates.into_iter().take(limit.min(3)) {
+            let row = serde_json::json!({"tool_name":tool.name,"description":tool.description,"input_schema":tool.parameters});
+            let mut proposed = results.clone(); proposed.push(row.clone());
+            if serde_json::to_vec(&proposed).unwrap().len() > 15000 {
+                // Preserve full schema validity; next request exposes everything
+                // rather than truncating the selected tool's argument contract.
+                self.full = true;
+                return serde_json::json!({"results":results,"note":"Schema result limit reached; full eligible tools will be advertised next request. No tools were executed."});
+            }
+            self.selected.insert(tool.name.clone(), fingerprint(tool));
+            results.push(row);
+        }
+        if self.selected.len() >= 8 { self.full = true; }
+        serde_json::json!({"results":results,"available":true,
+            "note":"Selected native schemas will be advertised next request. Call original tool names directly; all ordinary approvals and limits still apply. No tool executed."})
+    }
+}
+
+pub(crate) fn present(tools: &mut [ToolSpec], compact: bool) {
+    if !compact { return; }
+    for tool in tools {
+        // Match the complete known schema and description, not merely a name.
+        // Custom definitions and future schema revisions retain their full docs.
+        if let Some(entry) = catalog().iter().find(|entry| {
+            entry.name == tool.name && tool.description.as_deref() == Some(entry.original.as_str())
+                && entry.parameters == tool.parameters
+        }) {
+            tool.description = Some(entry.compact.clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn presentation_restart_reconciles_hints_and_child_restrictions() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = native_tools();
+        let hints = PresentationHints { mode: "adaptive".into(), selected: std::collections::BTreeMap::from([
+            ("image_gen".into(), fingerprint(&tools[2]))
+        ]) };
+        persist_hints(dir.path(), &hints).await.unwrap();
+        let deferred = std::collections::BTreeSet::from(["image_gen".into()]);
+        let mut restored = NativePresentation::load(dir.path());
+        assert_eq!(restored.mode.as_deref(), Some("adaptive"));
+        assert_eq!(restored.project("resumed", tools.clone(), &deferred, true).len(), 3);
+        // Compactions/model requests do not reset the running task's hints.
+        for _ in 0..2 { assert_eq!(restored.project("resumed", tools.clone(), &deferred, true).len(), 3); }
+        let mut child = NativePresentation::load(dir.path());
+        assert_eq!(child.project("child", tools[..2].to_vec(), &deferred, true).len(), 2);
+        assert!(child.selected.is_empty(), "restored hints cannot add child-ineligible tools");
+        assert_eq!(restored.selected.len(), 1, "child reconciliation is private");
+        let mut changed = tools.clone();
+        changed[2].parameters["required"] = serde_json::json!(["different"]);
+        let mut restarted = NativePresentation::load(dir.path());
+        assert_eq!(restarted.project("resumed", changed, &deferred, true).len(), 2);
+        assert!(restarted.selected.is_empty());
+    }
+
+    #[tokio::test]
+    async fn invalid_presentation_hints_never_restore_selection() {
+        let dir = tempfile::tempdir().unwrap();
+        let hints = PresentationHints { mode: "adaptive".into(), selected: std::collections::BTreeMap::from([
+            ("image_gen".into(), "not-a-fingerprint".into())
+        ]) };
+        persist_hints(dir.path(), &hints).await.unwrap();
+        assert!(NativePresentation::load(dir.path()).selected.is_empty());
+        std::fs::write(dir.path().join(HINTS_FILE), vec![b'x'; 8193]).unwrap();
+        assert!(NativePresentation::load(dir.path()).selected.is_empty());
+    }
+
+    fn native_tools() -> Vec<ToolSpec> {
+        vec![ToolSpec {name:"search_tool".into(),description:Some("Search MCP".into()),parameters:serde_json::json!({})},
+             ToolSpec {name:"read_file".into(),description:Some("Read".into()),parameters:serde_json::json!({})},
+             ToolSpec {name:"image_gen".into(),description:Some("Generate image artwork".into()),parameters:serde_json::json!({"type":"object","required":["prompt"]})}]
+    }
+
+    #[test]
+    fn native_discovery_activates_without_execution_and_preserves_schema() {
+        let mut state=NativePresentation::default();
+        let all=native_tools();
+        let deferred=std::collections::BTreeSet::from(["image_gen".into()]);
+        let visible=state.project("task",all.clone(),&deferred,true);
+        assert_eq!(visible.len(),2);
+        assert!(visible[0].description.as_ref().unwrap().contains("image_gen"));
+        let found=state.discover("image_gen",3);
+        assert_eq!(found["results"][0]["input_schema"],all[2].parameters);
+        let next=state.project("task",all.clone(),&deferred,true);
+        assert_eq!(next.len(),3);
+        assert_eq!(next[2].parameters,all[2].parameters);
+        assert_eq!(state.project("different-task",all,&deferred,true).len(),2);
+    }
+
+    #[test]
+    fn native_discovery_revocation_finalization_and_session_isolation() {
+        let mut state=NativePresentation::default();
+        let deferred=std::collections::BTreeSet::from(["image_gen".into()]);
+        state.project("task",native_tools(),&deferred,true);
+        state.discover("image",3);
+        let mut changed=native_tools(); changed[2].parameters["required"]=serde_json::json!(["prompt","approval"]);
+        assert_eq!(state.project("task",changed,&deferred,true).len(),2,"schema revision invalidates activation");
+        state.project("task",native_tools()[..2].to_vec(),&deferred,true);
+        assert_eq!(state.discover("image",3)["results"],serde_json::json!([]));
+        state.project("task",native_tools(),&deferred,false);
+        assert_eq!(state.discover("image",3)["available"],false);
+        assert!(NativePresentation::default().selected.is_empty());
+    }
+
+    #[test]
+    fn native_discovery_bounds_do_not_truncate_schema() {
+        let mut state=NativePresentation::default();
+        let mut tools=native_tools();
+        tools[2].parameters["description"]=serde_json::json!("x".repeat(17000));
+        let deferred=std::collections::BTreeSet::from(["image_gen".into()]);
+        state.project("task",tools.clone(),&deferred,true);
+        let result=state.discover("image",3);
+        assert!(result.to_string().len()<16000);
+        assert!(state.full);
+        assert_eq!(state.project("task",tools.clone(),&deferred,true)[2].parameters,tools[2].parameters);
+    }
+
+    fn fixture(entry: &Entry) -> ToolSpec {
+        ToolSpec { name: entry.name.clone(), description: Some(entry.original.clone()), parameters: entry.parameters.clone() }
+    }
+
+    #[test]
+    fn compact_presentation_preserves_every_structural_schema() {
+        let mut tools: Vec<_> = catalog().iter().map(fixture).collect();
+        let before = tools.clone();
+        present(&mut tools, true);
+        assert_eq!(tools.len(), before.len());
+        for (after, old) in tools.iter().zip(&before) {
+            assert_eq!(after.name, old.name);
+            assert_eq!(after.parameters, old.parameters);
+            assert!(after.description.as_ref().unwrap().len() < old.description.as_ref().unwrap().len());
+        }
+        let first = serde_json::to_value(&tools).unwrap();
+        present(&mut tools, true);
+        assert_eq!(serde_json::to_value(tools).unwrap(), first, "idempotent mirrored presentation");
+    }
+
+    #[test]
+    fn full_mode_and_custom_or_changed_definitions_are_untouched() {
+        let entry = &catalog()[0];
+        let mut full = vec![fixture(entry)];
+        let before = serde_json::to_value(&full).unwrap();
+        present(&mut full, false);
+        assert_eq!(serde_json::to_value(full).unwrap(), before);
+        let mut changed = vec![fixture(entry), fixture(entry), fixture(entry)];
+        changed[0].description = Some("custom policy: require extra approval".into());
+        changed[1].parameters["additionalProperties"] = serde_json::json!(false);
+        changed[2].name = "external__run_terminal_command".into();
+        let before = serde_json::to_value(&changed).unwrap();
+        present(&mut changed, true);
+        assert_eq!(serde_json::to_value(changed).unwrap(), before);
+    }
+
+    #[test]
+    fn compact_catalog_preserves_critical_usage_constraints() {
+        let get = |name| catalog().iter().find(|entry| entry.name == name).unwrap().compact.as_str();
+        for text in ["SIGTERM", "SIGKILL", "setsid/nohup", "timeout 0", "40000", "full-log", "do not poll"] {
+            assert!(get("run_terminal_command").contains(text), "{text}");
+        }
+        for text in ["exact", "indentation", "uniquely", "replace_all"] {
+            assert!(get("search_replace").contains(text), "{text}");
+        }
+        for text in ["immutable source/args", "restart is terminal", "higher", "not all branches"] {
+            assert!(get("workflow").contains(text), "{text}");
+        }
+    }
+}

--- a/crates/codegen/fuigo-shell/tests/native_discovery_acp.rs
+++ b/crates/codegen/fuigo-shell/tests/native_discovery_acp.rs
@@ -1,0 +1,125 @@
+//! Actual ACP → discovery → next-request schema activation, with fake inference.
+#[allow(dead_code)]
+mod acp_harness;
+use acp_harness::{AutoApproveClient, RPC_TIMEOUT, connect_client, new_session, prompt_turn, run_agent_test, spawn_agent_local_with_config};
+use agent_client_protocol::{self as acp, Agent as _};
+use fuigo_test_support::{ScriptedResponse, SseEvent};
+use serde_json::{Value,json};
+
+fn reply_tool(name: &str, args: Value) -> ScriptedResponse {
+    reply_tools(vec![(name, args)])
+}
+
+fn reply_tools(calls: Vec<(&str, Value)>) -> ScriptedResponse {
+    let calls: Vec<_> = calls.into_iter().enumerate().map(|(index, (name, args))| json!({
+        "index":index,"id":format!("discovery-call-{index}"),"type":"function",
+        "function":{"name":name,"arguments":args.to_string()}
+    })).collect();
+    ScriptedResponse::sse(vec![SseEvent::data(json!({
+        "id":"native-discovery-fixture", "object":"chat.completion.chunk", "created":0, "model":"test-model",
+        "choices":[{"index":0,"delta":{"role":"assistant","tool_calls":calls},"finish_reason":"tool_calls"}]
+    }).to_string()),SseEvent::data("[DONE]")])
+}
+
+#[test]
+fn native_discovery_activates_next_request_and_rejects_undiscovered_actions() {
+    unsafe {std::env::set_var("FUIGO_TOOL_PRESENTATION","adaptive");}
+    run_agent_test(|cwd,mock| async move {
+        mock.set_models(vec![fuigo_test_support::MockModelEntry::new("test-model"),fuigo_test_support::MockModelEntry::new("test-model-alternate")]);
+        std::fs::write(cwd.join("AGENTS.md"),"Retain NATIVE_DISCOVERY_POLICY_719.\n").unwrap();
+        let mut config=fuigo_shell::agent::config::Config::default();
+        config.session.title_policy=Some(fuigo_shell::agent::config::TitlePolicy::Local);
+        let (conn,_)=connect_client(AutoApproveClient,"native-discovery-test",spawn_agent_local_with_config(config)).await;
+        let session=new_session(&conn,&cwd).await;
+        mock.enqueue_response("/v1/chat/completions",reply_tool("search_tool",json!({"query":"image_gen","scope":"native"})));
+        prompt_turn(&conn,&session,"Discover the image tool, but do not execute it; then finish.").await;
+        let requests:Vec<Value>=mock.requests().iter().filter(|r|r.path=="/v1/chat/completions")
+            .filter_map(|r|r.body.as_ref().and_then(|b|serde_json::from_str(&b.to_string()).ok())).collect();
+        let has=|v:&Value,name:&str|v["tools"].as_array().is_some_and(|tools|tools.iter().any(|t|t["function"]["name"]==name));
+        assert!(requests.len()>=2,"discovery must yield a new model request");
+        assert!(!has(&requests[0],"image_gen"));
+        assert!(has(&requests[1],"image_gen"));
+        for request in &requests[..2] {
+            assert!(has(request,"read_file") && has(request,"use_tool") && has(request,"search_tool"));
+            assert!(request["messages"].to_string().contains("NATIVE_DISCOVERY_POLICY_719"));
+        }
+        let hostile=new_session(&conn,&cwd).await;
+        mock.enqueue_response("/v1/chat/completions",reply_tool("image_gen",json!({"prompt":"must never execute"})));
+        let result=tokio::time::timeout(RPC_TIMEOUT,conn.prompt(acp::PromptRequest::new(hostile,
+            vec![acp::ContentBlock::Text(acp::TextContent::new("Do not run image generation."))]))).await.unwrap();
+        assert!(result.unwrap_err().to_string().contains("not advertised"),"undiscovered action was not rejected before dispatch");
+        let same_batch=new_session(&conn,&cwd).await;
+        mock.enqueue_response("/v1/chat/completions",reply_tools(vec![
+            ("search_tool",json!({"query":"image_gen","scope":"native"})),
+            ("image_gen",json!({"prompt":"must never execute in discovery response"})),
+        ]));
+        let result=tokio::time::timeout(RPC_TIMEOUT,conn.prompt(acp::PromptRequest::new(same_batch,
+            vec![acp::ContentBlock::Text(acp::TextContent::new("Discover only; do not generate an image."))]))).await.unwrap();
+        assert!(result.unwrap_err().to_string().contains("not advertised"),"same-response discovery must not authorize a hidden action");
+        // A fresh agent must rebuild presentation from durable hints, not the
+        // old actor's mutable snapshot or conversation-tool output.
+        drop(conn);
+        let mut config=fuigo_shell::agent::config::Config::default();
+        config.session.title_policy=Some(fuigo_shell::agent::config::TitlePolicy::Local);
+        let (resumed,_)=connect_client(AutoApproveClient,"native-discovery-resume",spawn_agent_local_with_config(config)).await;
+        tokio::time::timeout(RPC_TIMEOUT,resumed.load_session(acp::LoadSessionRequest::new(session.clone(),cwd.clone())))
+            .await.unwrap().expect("fresh agent must load saved session");
+        let before=mock.requests().len();
+        prompt_turn(&resumed,&session,"Finish without executing any tools.").await;
+        let requests=mock.requests();
+        let next:Value=requests[before..].iter().find(|r|r.path=="/v1/chat/completions")
+            .and_then(|r|r.body.as_ref()).map(|body|serde_json::from_str(&body.to_string()).unwrap()).unwrap();
+        assert!(has(&next,"image_gen"),"fresh agent lost the discovered schema hint");
+        assert!(next["messages"].to_string().contains("NATIVE_DISCOVERY_POLICY_719"),"reload lost canonical instructions");
+        for round in 0..2 {
+            prompt_turn(&resumed,&session,&format!("Continuity fixture round {round}: {}", "completed observation; ".repeat(600))).await;
+            acp_harness::ext_method(&resumed,"fuigo/compact_conversation",json!({
+                "session_id":session.to_string(),"user_context":"Preserve the user's instructions; summarize completed observations."
+            })).await;
+            let before=mock.requests().len();
+            // Rediscovery is allowed on a new task, but must preserve eligibility
+            // and canonical instructions after each real compaction.
+            mock.enqueue_response("/v1/chat/completions",reply_tool("search_tool",json!({"query":"image_gen","scope":"native"})));
+            prompt_turn(&resumed,&session,"Discover image_gen without executing it, then finish.").await;
+            let captured=mock.requests();
+            let bodies:Vec<Value>=captured[before..].iter().filter(|r|r.path=="/v1/chat/completions")
+                .filter_map(|r|r.body.as_ref().map(|b|serde_json::from_str(&b.to_string()).unwrap())).collect();
+            assert!(bodies.iter().any(|b|has(b,"image_gen")),"compaction {round} lost native reachability");
+            assert!(bodies.iter().all(|b|b["messages"].to_string().contains("NATIVE_DISCOVERY_POLICY_719")),"compaction {round} lost canonical instructions");
+        }
+        tokio::time::timeout(RPC_TIMEOUT,resumed.set_session_model(acp::SetSessionModelRequest::new(
+            session.clone(),acp::ModelId::new("test-model-alternate")
+        ))).await.unwrap().expect("explicit model switch");
+        let before=mock.requests().len();
+        mock.enqueue_response("/v1/chat/completions",reply_tool("search_tool",json!({"query":"image_gen","scope":"native"})));
+        prompt_turn(&resumed,&session,"Discover image_gen without executing it, then finish.").await;
+        let captured=mock.requests();
+        let bodies:Vec<Value>=captured[before..].iter().filter(|r|r.path=="/v1/chat/completions")
+            .filter_map(|r|r.body.as_ref().map(|b|serde_json::from_str(&b.to_string()).unwrap())).collect();
+        assert!(!bodies.is_empty());
+        assert!(bodies.iter().all(|b|b["model"]=="test-model-alternate"),"switch did not reach inference requests");
+        assert!(bodies.iter().any(|b|has(b,"image_gen")),"switch lost native reachability");
+        assert!(bodies.iter().all(|b|b["messages"].to_string().contains("NATIVE_DISCOVERY_POLICY_719")),"switch lost canonical instructions");
+        // Reattach to the resident actor: the new host's pinned delivery tools
+        // must take effect, not the original actor's startup policy.
+        let pinned=new_session(&resumed,&cwd).await;
+        tokio::time::timeout(RPC_TIMEOUT,resumed.load_session(acp::LoadSessionRequest::new(pinned.clone(),cwd.clone())
+            .meta(json!({"startupHints":{"deliveryTools":["image_gen"],"nonInteractive":true}}).as_object().cloned())))
+            .await.unwrap().expect("host attachment policy");
+        let before=mock.requests().len();
+        prompt_turn(&resumed,&pinned,"Finish without calling tools.").await;
+        let captured=mock.requests();
+        let first:Value=captured[before..].iter().find(|r|r.path=="/v1/chat/completions")
+            .and_then(|r|r.body.as_ref()).map(|b|serde_json::from_str(&b.to_string()).unwrap()).unwrap();
+        assert!(has(&first,"image_gen"),"reattached host delivery tool was hidden");
+        tokio::time::timeout(RPC_TIMEOUT,resumed.load_session(acp::LoadSessionRequest::new(pinned.clone(),cwd.clone())
+            .meta(json!({"startupHints":{"deliveryTools":[],"nonInteractive":true}}).as_object().cloned())))
+            .await.unwrap().expect("host pin removal");
+        let before=mock.requests().len();
+        prompt_turn(&resumed,&pinned,"Finish without calling tools.").await;
+        let captured=mock.requests();
+        let first:Value=captured[before..].iter().find(|r|r.path=="/v1/chat/completions")
+            .and_then(|r|r.body.as_ref()).map(|b|serde_json::from_str(&b.to_string()).unwrap()).unwrap();
+        assert!(!has(&first,"image_gen"),"removed host pin remained advertised");
+    });
+}

--- a/crates/codegen/fuigo-shell/tests/presentation_child_acp.rs
+++ b/crates/codegen/fuigo-shell/tests/presentation_child_acp.rs
@@ -1,0 +1,62 @@
+//! Adaptive tool presentation must keep native child spawn reachable and must
+//! never advertise an undiscovered deferred schema to the parent or the child.
+//! One real native child on the existing ACP/mock harness, not a perf sweep.
+#[allow(dead_code)]
+mod acp_harness;
+#[path = "perf_harness/mod.rs"]
+mod perf_harness;
+#[path = "subagent_sweep_support/mod.rs"]
+mod support;
+
+use serde_json::Value;
+
+const DEFERRED_MEDIA: [&str; 4] = ["image_gen", "image_edit", "image_to_video", "reference_to_video"];
+
+fn tool_names(body: &Value) -> Vec<String> {
+    body["tools"]
+        .as_array()
+        .map(|tools| tools.iter().filter_map(|t| t["function"]["name"].as_str().map(str::to_string)).collect())
+        .unwrap_or_default()
+}
+
+#[test]
+fn adaptive_presentation_keeps_native_child_spawn_reachable() {
+    // One test per binary; set before any agent or mock threads exist.
+    unsafe {
+        std::env::set_var("FUIGO_TOOL_PRESENTATION", "adaptive");
+        std::env::set_var("FUIGO_MAX_MODEL_CALLS", "20");
+        std::env::set_var("FUIGO_SWEEP_DEADLINE_S", "60");
+        std::env::set_var("FUIGO_TURN_SUMMARY", "false");
+    }
+    let env = support::sweep_env_init();
+    let server = env
+        .mock_rt
+        .block_on(fuigo_test_support::MockInferenceServer::start())
+        .expect("mock server");
+    unsafe {
+        std::env::set_var("FUIGO_CLI_CHAT_PROXY_BASE_URL", server.url());
+        std::env::set_var("FUIGO_API_BASE_URL", server.url());
+    }
+    let outcome = support::run_burst(&server, 1, "none", env.deadline);
+    assert_eq!(outcome.rows.len(), 1, "one real native child must be observed");
+    assert_eq!(outcome.failures, 0, "native child did not complete under adaptive presentation");
+
+    let bodies: Vec<Value> = server
+        .requests()
+        .iter()
+        .filter(|r| r.path == "/v1/chat/completions")
+        .filter_map(|r| r.body.as_ref().and_then(|b| serde_json::from_str(&b.to_string()).ok()))
+        .collect();
+    assert!(bodies.len() >= 2, "expected parent and child inference requests, saw {}", bodies.len());
+    assert!(
+        bodies.iter().any(|b| tool_names(b).iter().any(|n| n == "spawn_subagent")),
+        "adaptive presentation hid native child spawn from the parent"
+    );
+    for body in &bodies {
+        let offered = tool_names(body);
+        assert!(
+            !offered.iter().any(|n| DEFERRED_MEDIA.contains(&n.as_str())),
+            "an undiscovered deferred media schema was advertised: {offered:?}"
+        );
+    }
+}

--- a/crates/codegen/fuigo-shell/tests/tool_presentation_acp.rs
+++ b/crates/codegen/fuigo-shell/tests/tool_presentation_acp.rs
@@ -1,0 +1,39 @@
+//! Real ACP/request assembly proof, fake provider, isolated session state.
+#[allow(dead_code)]
+mod acp_harness;
+
+use acp_harness::{AutoApproveClient, connect_and_auth, new_session, prompt_turn, run_agent_test};
+
+#[test]
+fn compact_presentation_keeps_instructions_and_native_schemas() {
+    // One test per binary; configure before mock or agent threads exist.
+    unsafe { std::env::set_var("FUIGO_TOOL_PRESENTATION", "compact"); }
+    run_agent_test(|cwd, mock| async move {
+        std::fs::write(cwd.join("AGENTS.md"), "Project convention: KEEP_COMPACT_INSTRUCTION_719.\n").unwrap();
+        let (conn, _) = connect_and_auth(AutoApproveClient, "compact-presentation-fixture").await;
+        let session = new_session(&conn, &cwd).await;
+        prompt_turn(&conn, &session, "Reply DONE without using tools.").await;
+        let requests: Vec<serde_json::Value> = mock.requests().iter()
+            .filter(|r| r.path == "/v1/chat/completions")
+            .filter_map(|r| r.body.as_ref().and_then(|b| serde_json::from_str(&b.to_string()).ok()))
+            .collect();
+        let request = requests.iter().find(|r| r["tools"].as_array().is_some_and(|tools|
+            tools.iter().any(|t| t["function"]["name"] == "read_file"))).expect("real main tool request");
+        assert!(request["messages"].to_string().contains("KEEP_COMPACT_INSTRUCTION_719"), "AGENTS instruction absent");
+        let tools = request["tools"].as_array().unwrap();
+        for required in ["read_file", "search_replace", "run_terminal_command", "search_tool", "use_tool"] {
+            assert!(tools.iter().any(|t| t["function"]["name"] == required), "lost tool {required}");
+        }
+        let catalog: Vec<serde_json::Value> = serde_json::from_str(include_str!("../src/session/compact_tool_descriptions.json")).unwrap();
+        let mut applied = 0;
+        for entry in catalog {
+            if let Some(tool) = tools.iter().find(|t| t["function"]["name"] == entry["name"]) {
+                if tool["function"]["description"] == entry["compact"] {
+                    assert_eq!(tool["function"]["parameters"], entry["parameters"]);
+                    applied += 1;
+                }
+            }
+        }
+        assert!(applied >= 5, "compact presentation did not activate on built-ins: {applied}");
+    });
+}

--- a/crates/codegen/fuigo-tools/src/implementations/search_tool/mod.rs
+++ b/crates/codegen/fuigo-tools/src/implementations/search_tool/mod.rs
@@ -274,6 +274,12 @@ impl fuigo_tool_runtime::Tool for SearchTool {
         };
         let tool_index = tool_index.0.clone();
 
+        if input.scope == types::SearchScope::Native {
+            return Ok(ToolOutput::Text(
+                tool_index.discover_native(&input.query, input.limit.unwrap_or(3) as usize).to_string().into(),
+            ));
+        }
+
         let limit = input.limit.unwrap_or(5) as usize;
         let snapshot = tool_index.search_snapshot(&input.query, limit);
 
@@ -412,6 +418,7 @@ mod tests {
                 ctx,
                 SearchToolInput {
                     query: "grafana".into(),
+                    scope: Default::default(),
                     limit: Some(5),
                 },
             )
@@ -454,6 +461,7 @@ mod tests {
                 ctx,
                 SearchToolInput {
                     query: "confluence".into(),
+                    scope: Default::default(),
                     limit: Some(5),
                 },
             )

--- a/crates/codegen/fuigo-tools/src/implementations/search_tool/types.rs
+++ b/crates/codegen/fuigo-tools/src/implementations/search_tool/types.rs
@@ -3,9 +3,21 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SearchScope {
+    #[default]
+    Mcp,
+    Native,
+}
+
 /// Input for the `search_tool` tool.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct SearchToolInput {
+    /// MCP integrations by default. Native reveals eligible deferred built-in
+    /// schemas for the next request; invoke those tools by their original names.
+    #[serde(default)]
+    pub scope: SearchScope,
     /// Keywords to match against tool names, server names, and descriptions.
     /// Include the server name and action for best results
     /// (e.g. "linear create issue", "slack read thread history").
@@ -17,4 +29,17 @@ pub struct SearchToolInput {
 
 fn default_limit() -> Option<u8> {
     Some(5)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn native_discovery_scope_is_explicit_and_old_input_stays_mcp() {
+        let old: SearchToolInput=serde_json::from_str(r#"{"query":"images"}"#).unwrap();
+        assert_eq!(old.scope,SearchScope::Mcp);
+        let native: SearchToolInput=serde_json::from_str(r#"{"query":"images","scope":"native"}"#).unwrap();
+        assert_eq!(native.scope,SearchScope::Native);
+        assert!(serde_json::from_str::<SearchToolInput>(r#"{"query":"images","scope":"all-powerful"}"#).is_err());
+    }
 }

--- a/crates/codegen/fuigo-tools/src/types/tool_index.rs
+++ b/crates/codegen/fuigo-tools/src/types/tool_index.rs
@@ -56,6 +56,11 @@ pub struct ServerSummary {
 /// in `Resources`. No MCP-specific concepts — the concrete implementation
 /// in `fuigo-shell` maps `mcp_initialized` to `is_ready`.
 pub trait ToolSearchIndex: Send + Sync {
+    /// Presentation discovery only, never approval or execution. Old backends
+    /// have no native catalog and retain their existing MCP behavior.
+    fn discover_native(&self, _query: &str, _limit: usize) -> serde_json::Value {
+        serde_json::json!({"results": [], "available": false, "note": "Native discovery unavailable"})
+    }
     /// Search and return results + metadata from a single consistent snapshot.
     fn search_snapshot(&self, query: &str, limit: usize) -> SearchSnapshot;
 

--- a/crates/codegen/fuigo-version/Cargo.toml
+++ b/crates/codegen/fuigo-version/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 license = "Apache-2.0"
 name = "fuigo-version"
-version = "1.0.10"
+version = "1.0.11"
 edition.workspace = true
 description = "Lockstepped fuigo CLI version."
 

--- a/docs/compact-tool-presentation.md
+++ b/docs/compact-tool-presentation.md
@@ -1,0 +1,39 @@
+# Experimental compact tool descriptions
+
+This worktree adds an opt-in presentation layer to the normal agent:
+
+```sh
+FUIGO_TOOL_PRESENTATION=compact fuigo
+```
+
+New sessions default to full descriptions. The mode is saved with a session;
+set `FUIGO_TOOL_PRESENTATION=full` to override it on resume. An explicit process
+setting takes precedence over saved preferences; unknown values mean full.
+It does not select the separate
+`fuigo-build-concise` agent or disable AGENTS.md.
+
+Only13 verified built-in top-level descriptions are shortened. Matching requires
+the exact native name, original description and parameter schema. Custom tools,
+changed schemas and unmatched dynamic descriptions retain their original text.
+Every tool name, parameter validation rule, registered implementation, permission,
+hook, result and hosted-tool configuration remains unchanged. Full original
+descriptions are retained in the source catalog and tool registry.
+
+`FUIGO_TOOL_PRESENTATION=adaptive` additionally defers eligible media-generation
+schemas until `search_tool` with `scope: "native"` discovers them. Coding, job-control,
+workflow, memory and MCP tools remain visible. Host-declared delivery tools stay pinned.
+The full registry remains available; call discovered native tools by their original
+names on the next request, never via `use_tool`. Discovery grants no permission.
+Ordinary finalization and child restrictions apply before exposure. Memory-only
+classification uses the full eligible set, not its smaller advertised subset.
+Changed/removed schemas invalidate activation. Oversize results or eight activations
+switch to full eligible presentation; schemas are never silently truncated.
+Bounded selection fingerprints and mode are saved through the session persistence
+actor. On reload they are intersected with currently eligible definitions; changed
+schemas are rediscovered. Invalid/oversized hints are ignored with a warning.
+These hints are never permission state and cannot restore old authority.
+The function is idempotent for already-presented fork/mirror tool definitions.
+
+Status: experimental candidate, not part of published1.0.10. Predicted description
+reduction is not a measured total-token saving. Adoption awaits structural and
+actual-ACP parity checks, followed by the plan's workload measurement gates.

--- a/scripts/agent-bench-builder.Dockerfile
+++ b/scripts/agent-bench-builder.Dockerfile
@@ -1,0 +1,11 @@
+# Task-owned Linux build environment; does not modify the shared buildbox host.
+FROM wayland-core-ci:rust-1.95-slim-bookworm
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    make cmake protobuf-compiler clang libclang-dev nasm ninja-build meson \
+    libssl-dev libdbus-1-dev libudev-dev libasound2-dev
+# Rust 1.94 is mounted read-only from the buildbox's existing toolchain.
+ENV PATH="/opt/fuigo-rust/bin:${PATH}"
+ENV CARGO_HOME=/build/cargo CARGO_TARGET_DIR=/build/target
+ENV PROTOC=/usr/bin/protoc CARGO_BUILD_JOBS=4 CARGO_INCREMENTAL=0
+WORKDIR /src


### PR DESCRIPTION
## Summary

- Adds an opt-in `FUIGO_TOOL_PRESENTATION` setting for the normal agent. The default stays `full`.
- `compact` shortens the descriptions of 13 verified built-in tools. Tool names, parameter schemas, permissions, hooks and AGENTS.md are unchanged. Custom or changed definitions keep their original text.
- `adaptive` does everything `compact` does and also holds back eligible media-generation schemas until `search_tool` with `scope: "native"` discovers them. Discovered tools run through the normal dispatcher under their original names.
- Discovery never grants permission. Finalization and child restrictions apply before exposure, and a changed or removed schema invalidates activation.
- The mode and bounded selection hints persist with the session and are re-checked against live schemas on reload.
- `search_tool` gains an optional `scope` field that defaults to `mcp`. That adds 238 bytes to the full schema.
- Bumps the version to 1.0.11.

## Benchmark: every frozen adoption gate passed

Paired DeepSeek cohort: released 1.0.10 with default presentation against this build with `adaptive`. 10 cases, 3 repeats per arm, 60 observations, complete.

| Metric | 1.0.10 | 1.0.11 adaptive | Change |
|---|---:|---:|---:|
| Correct normal completions | 26/30 | 27/30 | +1 |
| Protected file kept in denial cases | 3/3 | 3/3 | Equal |
| Input+output tokens per accepted task | 102,349 | 76,402 | **-25.4%** |
| Reported input tokens | 2,595,592 | 2,002,800 | -22.8% |
| Reported output tokens | 65,487 | 60,051 | -8.3% |
| Provider calls | 241 | 234 | -2.9% |
| Paired median task time ratio | | 0.925 | |
| Live median tool-schema bytes | 36,780 | 26,063 | -29.1% |

| Gate | Threshold | Result |
|---|---|---|
| Schema bytes | at least 25% fewer | 29.1% fewer |
| Tokens per accepted task | at least 15% fewer | 25.4% fewer |
| Accepted tasks | not lower | 27 vs 26 |
| Request count | at most 1.10x | 0.97x |
| Paired median latency | at most 1.10x | 0.92x |
| Cost | under 1.25x | 0.97x |

The only non-denial failure was in the 1.0.10 arm. Denial cases record a non-normal stop in both arms by design, with the protected file kept. Savings appeared in 8 of 10 cases. Limits: one inexpensive model, synthetic tasks, 30 observations per arm, usage-derived cost without invoice reconciliation. This is not a cross-harness ranking.

## Other verification

All offline checks use fake inference with no external network.

| Check | Result |
|---|---|
| ACP native discovery: activation, rejection of undiscovered and same-batch calls, fresh-agent reload, two real compactions, model switch, host pin add and remove | Passed |
| ACP compact presentation with an AGENTS.md sentinel | Passed |
| Storage fork and reload authority regression | Passed |
| Adaptive parent with a real native child (`presentation_child_acp`) | Passed |
| Real CLI schema witness: full and compact keep all 24 tools; adaptive defers only 4 media tools; AGENTS.md present in every mode | Passed |
| Murage ACP call sequence against the Linux release build, full and adaptive | Passed |
| Linux x64 release build | Passed |
| Six-platform no-publish release dry run | https://github.com/FerroxLabs/fuigo/actions/runs/34483241399 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUhZPqLBtQEsKvymnJmNvd
