### PR TITLE
fix(mcp): project host-supplied server names onto the tool-id charset

### DIFF
--- a/crates/codegen/fuigo-mcp/src/servers.rs
+++ b/crates/codegen/fuigo-mcp/src/servers.rs
@@ -4878,7 +4878,9 @@ pub async fn start_mcp_servers(
 ///
 /// - every character outside `[A-Za-z0-9_-]` becomes `-`
 /// - a run of two or more `_` collapses to one, so the single `__` boundary stays unambiguous
-/// - leading and trailing `-` are trimmed; an empty result becomes `mcp`
+/// - leading and trailing `-` and `_` are trimmed (an edge `_` would fuse with the `__`
+///   delimiter into `___`, which [`parse_mcp_qualified_name`] rejects as ambiguous); an empty
+///   result becomes `mcp`
 ///
 /// Identity for a name that is already well-formed, so hosts with clean names see no change.
 pub fn sanitize_mcp_server_name(raw: &str) -> String {
@@ -4902,7 +4904,7 @@ pub fn sanitize_mcp_server_name(raw: &str) -> String {
         }
         out.push(mapped);
     }
-    let trimmed = out.trim_matches('-');
+    let trimmed = out.trim_matches(|c| c == '-' || c == '_');
     if trimmed.is_empty() {
         "mcp".to_owned()
     } else {

--- a/crates/codegen/fuigo-mcp/src/servers.rs
+++ b/crates/codegen/fuigo-mcp/src/servers.rs
@@ -4868,6 +4868,59 @@ pub async fn start_mcp_servers(
     .await
 }
 
+/// Project a host-supplied MCP server name onto the tool-id charset.
+///
+/// A server name is the namespace half of every `server__tool` qualified name the model
+/// sees, and a tool id admits only `[A-Za-z0-9_-]` per segment (see [`parse_mcp_qualified_name`]
+/// and `fuigo_tool_protocol::ToolId`) - the rule the provider APIs impose on function names.
+/// A host that keys connectors by reverse-DNS ids (`com.microsoft-playwright-mcp`) otherwise
+/// loses every tool on that server to "Skipping MCP tool with invalid or ambiguous qualified name".
+///
+/// - every character outside `[A-Za-z0-9_-]` becomes `-`
+/// - a run of two or more `_` collapses to one, so the single `__` boundary stays unambiguous
+/// - leading and trailing `-` are trimmed; an empty result becomes `mcp`
+///
+/// Identity for a name that is already well-formed, so hosts with clean names see no change.
+pub fn sanitize_mcp_server_name(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut underscores = 0usize;
+    for ch in raw.chars() {
+        let mapped = if ch.is_ascii_alphanumeric() || ch == '-' {
+            ch
+        } else if ch == '_' {
+            '_'
+        } else {
+            '-'
+        };
+        if mapped == '_' {
+            underscores += 1;
+            if underscores > 1 {
+                continue;
+            }
+        } else {
+            underscores = 0;
+        }
+        out.push(mapped);
+    }
+    let trimmed = out.trim_matches('-');
+    if trimmed.is_empty() {
+        "mcp".to_owned()
+    } else {
+        trimmed.to_owned()
+    }
+}
+
+/// Replace the name inside an MCP server enum variant.
+pub fn set_mcp_server_name(server: &mut acp::McpServer, name: String) {
+    match server {
+        acp::McpServer::Stdio(stdio) => stdio.name = name,
+        acp::McpServer::Http(http) => http.name = name,
+        acp::McpServer::Sse(sse) => sse.name = name,
+        // TODO(acp-0.10): `McpServer` is #[non_exhaustive].
+        _ => {}
+    }
+}
+
 /// Extract the name from an MCP server enum variant.
 pub fn mcp_server_name(server: &acp::McpServer) -> &str {
     match server {

--- a/crates/codegen/fuigo-mcp/src/servers_tests.rs
+++ b/crates/codegen/fuigo-mcp/src/servers_tests.rs
@@ -4172,6 +4172,15 @@ mod server_name_sanitizing {
         assert_eq!(sanitize_mcp_server_name("caf\u{e9}"), "caf");
         assert_eq!(sanitize_mcp_server_name("..."), "mcp");
         assert_eq!(sanitize_mcp_server_name(""), "mcp");
+        // An edge `_` would fuse with the `__` delimiter into `___`, an ambiguous qualified name.
+        assert_eq!(sanitize_mcp_server_name("com.foo_"), "com-foo");
+        assert_eq!(sanitize_mcp_server_name("_lead"), "lead");
+        assert_eq!(sanitize_mcp_server_name("_-_"), "mcp");
+        assert!(parse_mcp_qualified_name("com-foo___tool").is_none());
+        assert!(
+            parse_mcp_qualified_name(&format!("{}__tool", sanitize_mcp_server_name("com.foo_")))
+                .is_some()
+        );
     }
 
     #[test]

--- a/crates/codegen/fuigo-mcp/src/servers_tests.rs
+++ b/crates/codegen/fuigo-mcp/src/servers_tests.rs
@@ -4122,3 +4122,95 @@ async fn grok_agent_id_header_rejects_invalid_session_id() {
     };
     assert!(error.to_string().contains("invalid X-Grok-Agent-ID value"));
 }
+
+mod server_name_sanitizing {
+    use super::*;
+
+    #[test]
+    fn identity_for_well_formed_names() {
+        // Every name a known host sends today, verbatim: Murage's four and a few common shapes.
+        for name in [
+            "agents",
+            "browser",
+            "composio",
+            "computer",
+            "github",
+            "chrome-devtools",
+            "my_server-2",
+            "A1",
+        ] {
+            assert_eq!(
+                sanitize_mcp_server_name(name),
+                name,
+                "{name} must pass through unchanged"
+            );
+        }
+    }
+
+    #[test]
+    fn reverse_dns_ids_become_tool_id_safe() {
+        assert_eq!(
+            sanitize_mcp_server_name("com.microsoft-playwright-mcp"),
+            "com-microsoft-playwright-mcp"
+        );
+        assert_eq!(
+            sanitize_mcp_server_name("com.notion-notion-mcp"),
+            "com-notion-notion-mcp"
+        );
+        assert_eq!(
+            sanitize_mcp_server_name("com.github-github-mcp-server"),
+            "com-github-github-mcp-server"
+        );
+    }
+
+    #[test]
+    fn delimiter_runs_collapse_and_edges_trim() {
+        assert_eq!(sanitize_mcp_server_name("a__b"), "a_b");
+        assert_eq!(sanitize_mcp_server_name("a___b"), "a_b");
+        assert_eq!(sanitize_mcp_server_name(".hidden."), "hidden");
+        assert_eq!(sanitize_mcp_server_name("a b/c"), "a-b-c");
+        assert_eq!(sanitize_mcp_server_name("caf\u{e9}"), "caf");
+        assert_eq!(sanitize_mcp_server_name("..."), "mcp");
+        assert_eq!(sanitize_mcp_server_name(""), "mcp");
+    }
+
+    #[test]
+    fn sanitized_name_yields_a_registrable_qualified_name() {
+        let raw = "com.microsoft-playwright-mcp";
+        let broken = format!("{raw}{MCP_TOOL_NAME_DELIMITER}browser_click");
+        assert!(
+            parse_mcp_qualified_name(&broken).is_none(),
+            "the raw reverse-DNS name is rejected by the tool-id charset; that is the defect"
+        );
+        let fixed = format!(
+            "{}{MCP_TOOL_NAME_DELIMITER}browser_click",
+            sanitize_mcp_server_name(raw)
+        );
+        let (_, server, tool) = parse_mcp_qualified_name(&fixed).expect("sanitized name registers");
+        assert_eq!(server, "com-microsoft-playwright-mcp");
+        assert_eq!(tool, "browser_click");
+        assert!(validate_tool_name(&fixed).is_ok());
+    }
+
+    #[test]
+    fn set_name_round_trips_through_every_variant() {
+        let mut stdio = acp::McpServer::Stdio(acp::McpServerStdio::new(
+            "x".to_string(),
+            PathBuf::from("cmd"),
+        ));
+        set_mcp_server_name(&mut stdio, "y".to_string());
+        assert_eq!(mcp_server_name(&stdio), "y");
+        let mut http = acp::McpServer::Http(acp::McpServerHttp::new(
+            "x".to_string(),
+            "https://e/".to_string(),
+        ));
+        set_mcp_server_name(&mut http, "y".to_string());
+        assert_eq!(mcp_server_name(&http), "y");
+        let mut sse = acp::McpServer::Sse(acp::McpServerSse::new(
+            "x".to_string(),
+            "https://e/".to_string(),
+        ));
+        set_mcp_server_name(&mut sse, "y".to_string());
+        assert_eq!(mcp_server_name(&sse), "y");
+    }
+}

--- a/crates/codegen/fuigo-shell/src/session/managed_mcp.rs
+++ b/crates/codegen/fuigo-shell/src/session/managed_mcp.rs
@@ -113,12 +113,53 @@ pub(crate) fn admit_client_mcp_servers(
         );
     }
     if blocked.is_empty() {
-        return client_mcp_servers;
+        return normalize_client_mcp_server_names(client_mcp_servers);
     }
-    client_mcp_servers
-        .into_iter()
-        .filter(|s| !blocked.contains(&mcp_vendor_block_key(s)))
-        .collect()
+    // Block by the raw name first: a vendor entry is matched on what the client sent, not on the projected name.
+    normalize_client_mcp_server_names(
+        client_mcp_servers
+            .into_iter()
+            .filter(|s| !blocked.contains(&mcp_vendor_block_key(s)))
+            .collect(),
+    )
+}
+
+/// Rename client servers whose name cannot be a tool-id segment (see
+/// [`fuigo_mcp::servers::sanitize_mcp_server_name`]) so their tools register instead of
+/// being skipped. A name that is already well-formed is never touched, so a host whose ids
+/// are clean sees exactly today's behaviour, duplicates included. Only a *renamed* server can
+/// collide with another name in the list; it gets a `-2`, `-3`, ... suffix in list order.
+/// Each rename is logged so a host can see the name to expect in `tool_call` ids.
+fn normalize_client_mcp_server_names(servers: Vec<acp::McpServer>) -> Vec<acp::McpServer> {
+    use fuigo_mcp::servers::{sanitize_mcp_server_name, set_mcp_server_name};
+    let mut taken: std::collections::HashSet<String> = servers
+        .iter()
+        .map(|s| mcp_server_name(s).to_owned())
+        .collect();
+    let mut out = Vec::with_capacity(servers.len());
+    for mut server in servers {
+        let raw = mcp_server_name(&server).to_owned();
+        let sanitized = sanitize_mcp_server_name(&raw);
+        if sanitized == raw {
+            out.push(server);
+            continue;
+        }
+        let mut name = sanitized.clone();
+        let mut n = 2;
+        while taken.contains(&name) {
+            name = format!("{sanitized}-{n}");
+            n += 1;
+        }
+        taken.insert(name.clone());
+        tracing::warn!(
+            from = %raw,
+            to = %name,
+            "MCP server renamed: name is not a valid tool-id segment ([A-Za-z0-9_-], single `__`); tools register under the new name"
+        );
+        set_mcp_server_name(&mut server, name);
+        out.push(server);
+    }
+    out
 }
 
 pub(crate) fn merge_managed_mcp_servers_with_policy(
@@ -548,6 +589,85 @@ mod tests {
 
     fn client_stdio(name: &str) -> acp::McpServer {
         acp::McpServer::Stdio(acp::McpServerStdio::new(name.to_string(), "true"))
+    }
+
+    fn names(servers: &[acp::McpServer]) -> Vec<&str> {
+        servers.iter().map(mcp_server_name).collect()
+    }
+
+    /// A host that keys connectors by reverse-DNS id must still get tools: the name is projected
+    /// onto the tool-id charset at admission, before anything downstream keys on it.
+    #[test]
+    fn admit_renames_reverse_dns_client_servers() {
+        let cwd = empty_cwd();
+        let compat = fuigo_tools::types::compat::CompatConfig::default();
+        let admitted = admit_client_mcp_servers(
+            vec![
+                client_stdio("com.microsoft-playwright-mcp"),
+                client_stdio("com.notion-notion-mcp"),
+            ],
+            cwd.path(),
+            &compat,
+        );
+        assert_eq!(
+            names(&admitted),
+            vec!["com-microsoft-playwright-mcp", "com-notion-notion-mcp"]
+        );
+    }
+
+    /// Murage's four server names, verbatim: admission must be the identity for them, duplicates
+    /// included (the merge dedupes by name later exactly as before).
+    #[test]
+    fn admit_is_identity_for_well_formed_client_names() {
+        let cwd = empty_cwd();
+        let compat = fuigo_tools::types::compat::CompatConfig::default();
+        let input = vec![
+            client_stdio("agents"),
+            client_stdio("browser"),
+            client_stdio("composio"),
+            client_stdio("computer"),
+            client_stdio("computer"),
+        ];
+        let admitted = admit_client_mcp_servers(input.clone(), cwd.path(), &compat);
+        assert_eq!(names(&admitted), names(&input));
+    }
+
+    /// Only a renamed server can collide; it takes a numeric suffix rather than shadowing a
+    /// server whose name was already clean.
+    #[test]
+    fn admit_suffixes_a_renamed_server_that_collides() {
+        let cwd = empty_cwd();
+        let compat = fuigo_tools::types::compat::CompatConfig::default();
+        let admitted = admit_client_mcp_servers(
+            vec![
+                client_stdio("com-x"),
+                client_stdio("com.x"),
+                client_stdio("com_x"),
+                client_stdio("com x"),
+            ],
+            cwd.path(),
+            &compat,
+        );
+        assert_eq!(
+            names(&admitted),
+            vec!["com-x", "com-x-2", "com_x", "com-x-3"]
+        );
+    }
+
+    /// The vendor kill switch matches on the raw client name; projecting first would let a
+    /// blocked dotted vendor server slip through under its new name.
+    #[test]
+    fn admit_blocks_by_raw_name_before_renaming() {
+        let cwd = empty_cwd();
+        write_cursor_project_mcp(cwd.path(), "com.blocked");
+        let mut compat = fuigo_tools::types::compat::CompatConfig::default();
+        compat.cursor.mcps = false;
+        let admitted = admit_client_mcp_servers(
+            vec![client_stdio("com.blocked"), client_stdio("com.kept")],
+            cwd.path(),
+            &compat,
+        );
+        assert_eq!(names(&admitted), vec!["com-kept"]);
     }
 
     /// Vendor mcps kill switch must drop client-forwarded servers that match on-disk vendor config (pager may still load with default-on compat).


### PR DESCRIPTION
fix(mcp): project host-supplied server names onto the tool-id charset

## Problem

A host that keys its MCP connectors by reverse-DNS id loses every tool on those servers. Wayland Desktop sends `session/new` with `mcpServers` named `com.microsoft-playwright-mcp`, `com.github-github-mcp-server`, `com.notion-notion-mcp`; Fuigo composes the model-facing tool name as `server__tool`, and `fuigo_tool_protocol::ToolId` admits only `[A-Za-z0-9_-]` per segment (the same rule the provider APIs impose on function names). Every tool on a dotted server is dropped at registration:

    ERROR Skipping MCP tool with invalid or ambiguous qualified name server=com.microsoft-playwright-mcp tool=browser_click

438 of those in one Wayland session; the connectors connect and then have no tools.

The charset cannot simply be widened: a dot is illegal in an OpenAI/Anthropic function name. The name has to be projected, the way Claude Code projects `mcp__server__tool`.

## Change

- `fuigo_mcp::servers::sanitize_mcp_server_name(raw)`: every char outside `[A-Za-z0-9_-]` becomes `-`; a run of two or more `_` collapses to one (the single `__` boundary stays unambiguous); leading/trailing `-` trimmed; empty becomes `mcp`. Identity for a well-formed name.
- `fuigo_mcp::servers::set_mcp_server_name` (the write-side twin of `mcp_server_name`).
- `admit_client_mcp_servers` (fuigo-shell) applies the projection as its last step, so `session/new`, `session/load` and `fuigo/session/update_mcp_servers` all normalise once, before anything downstream keys on the name (merge map, dispatch, permission manager, prompter, tool ids). The vendor kill-switch still matches on the raw client name, so a blocked dotted vendor server cannot slip through under its new name.
- Only a renamed server can collide with another name in the list; it gets `-2`, `-3`, ... in list order. Servers whose names were already clean are never touched, duplicates included, so the merge-by-name dedupe behaves exactly as before.
- One `warn!` per rename (`from`, `to`) so a host can see the name to expect in `tool_call` ids.

Config-file (`[mcp_servers.<name>]`) and plugin servers are not touched by this PR; those names are typed by the Fuigo user and can be fixed at the keyboard.

## Why this is safe for Murage

Murage sends exactly four server names on `session/new`: `agents`, `browser`, `composio`, `computer` (`server/drivers/acp/core.ts`). All four are already inside the charset, so the projection is the identity function for every one of them: the code path taken is `sanitized == raw` -> push unchanged. `admit_is_identity_for_well_formed_client_names` pins those four names verbatim (with a duplicate) and asserts the admitted list is byte-for-byte the input.

## Tests

fuigo-mcp (`server_name_sanitizing`):
- identity for well-formed names (Murage's four plus common shapes)
- reverse-DNS ids project as expected
- `__` runs collapse, edges trim, empty -> `mcp`
- the raw dotted qualified name is rejected by `parse_mcp_qualified_name` (documents the defect) and the projected one parses and passes `validate_tool_name`
- `set_mcp_server_name` round-trips through Stdio/Http/Sse

fuigo-shell (`managed_mcp::tests`):
- `admit_renames_reverse_dns_client_servers`
- `admit_is_identity_for_well_formed_client_names`
- `admit_suffixes_a_renamed_server_that_collides` (`com-x`, `com.x`, `com_x`, `com x` -> `com-x`, `com-x-2`, `com_x`, `com-x-3`)
- `admit_blocks_by_raw_name_before_renaming`

Live, debug build of this branch vs the shipped 1.0.13 binary, real FluxRouter, a one-tool stdio MCP server (`canary_ping` returns a token), prompt "call canary_ping and reply with exactly what it returns", interleaved A/B:

| server name | shipped 1.0.13 | this branch |
|---|---|---|
| `com.microsoft-playwright-mcp` | tool skipped ("invalid or ambiguous qualified name"), canary absent, 2/2 | tool called, canary returned, 2/2 |
| `browser` (Murage-style) | tool called, canary returned, 2/2 | tool called, canary returned, 2/2 |

`cargo test -p fuigo-mcp`: 217 passed, 0 failed. `cargo test -p fuigo-shell managed_mcp`: 30 passed, 0 failed. rustfmt clean on the touched files (the crates are not rustfmt-clean at HEAD; nothing else was reformatted).

## Host impact

A host that sends a dotted name will see the projected name in `tool_call` ids (`com-microsoft-playwright-mcp__browser_click`). Wayland does not parse server names back out of Fuigo tool ids (its receipt matcher keys on the `mcp__` prefix Fuigo never emits), so it needs no reverse map.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvuJEwapJMLSJ7BCaSbeuW
