### PR TITLE
Fuigo 1.0.14: host-supplied MCP server names projected onto the tool-id charset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "fuigo-version"
-version = "1.0.13"
+version = "1.0.14"
 dependencies = [
  "semver",
 ]

--- a/crates/codegen/fuigo-pager/npm/fuigo-darwin-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/darwin-arm64",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "description": "darwin-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-darwin-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/darwin-x64",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "description": "darwin-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-linux-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/linux-arm64",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "description": "linux-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-linux-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/linux-x64",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "description": "linux-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-win32-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/win32-arm64",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "description": "win32-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-win32-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/win32-x64",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "description": "win32-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fuigo",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "description": "Bring Fuigo into your terminal",
     "license": "Apache-2.0",
     "bin": {
@@ -40,11 +40,11 @@
         "@iarna/toml": "^3.0.0"
     },
     "optionalDependencies": {
-        "@fuigo/darwin-arm64": "1.0.13",
-        "@fuigo/darwin-x64": "1.0.13",
-        "@fuigo/linux-arm64": "1.0.13",
-        "@fuigo/linux-x64": "1.0.13",
-        "@fuigo/win32-arm64": "1.0.13",
-        "@fuigo/win32-x64": "1.0.13"
+        "@fuigo/darwin-arm64": "1.0.14",
+        "@fuigo/darwin-x64": "1.0.14",
+        "@fuigo/linux-arm64": "1.0.14",
+        "@fuigo/linux-x64": "1.0.14",
+        "@fuigo/win32-arm64": "1.0.14",
+        "@fuigo/win32-x64": "1.0.14"
     }
 }

--- a/crates/codegen/fuigo-version/Cargo.toml
+++ b/crates/codegen/fuigo-version/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 license = "Apache-2.0"
 name = "fuigo-version"
-version = "1.0.13"
+version = "1.0.14"
 edition.workspace = true
 description = "Lockstepped fuigo CLI version."
 


### PR DESCRIPTION
Version bump only; the change is already on main via #10.

## What ships

- **MCP servers supplied by the host (`session/new`, `session/load`, `fuigo/session/update_mcp_servers`) with names outside `[A-Za-z0-9_-]` no longer lose every tool.** Reverse-DNS ids such as `com.microsoft-playwright-mcp` are projected onto the tool-id charset at admission (`com-microsoft-playwright-mcp`), so their tools register instead of being skipped with "invalid or ambiguous qualified name". Well-formed names are untouched (identity, duplicates included); only a renamed server can collide and takes a `-2`, `-3` suffix; the vendor kill switch still matches the raw name; one `warn!` per rename tells the host the name to expect in `tool_call` ids. Edge `_` is trimmed too, since `name___tool` is ambiguous. (#10)

No prompt, tool-default, or request-layer change from 1.0.13, so the 1.0.12 Sol gate stands.

## Verification

- #10 on hetzner (merged with 1.0.13 main): fuigo-mcp lib 217/217 (one test needs networking, passes with it), fuigo-shell `managed_mcp` 34/34.
- Release run on the tag builds all six targets and runs the security gate and darwin memory smokes before any npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)