### PR TITLE
fix(mcp): retry an HTTP handshake at 2025-11-25 when the server rejects the requested version's session

### DIFF
--- a/crates/codegen/fuigo-mcp/src/servers.rs
+++ b/crates/codegen/fuigo-mcp/src/servers.rs
@@ -3050,6 +3050,33 @@ fn restorable_transport(pending: &PendingTransport) -> Option<PendingTransport> 
     }
 }
 
+/// Like [`restorable_transport`], but only for the HTTP transports whose sessions live on the
+/// server: those are the ones that can bind a session to the protocol version the client REQUESTED
+/// rather than the one the server negotiated. Stdio has no server-side session; the ACP bridge is
+/// in-process.
+fn restorable_http_transport(pending: &PendingTransport) -> Option<PendingTransport> {
+    match pending {
+        PendingTransport::Http(_) | PendingTransport::HttpAuth { .. } => {
+            restorable_transport(pending)
+        }
+        PendingTransport::Stdio(_) | PendingTransport::Acp { .. } => None,
+    }
+}
+
+/// The protocol version this client asks for on the first `initialize`.
+///
+/// This pin currently equals rmcp 3.2 LATEST. The explicit constant must remain so a future rmcp
+/// bump cannot silently move the wire. 2026-07-28 brings SEP-2322 multi round-trip requests
+/// (`input_required` results); older servers negotiate down and keep the server-initiated
+/// `elicitation/create` flow.
+const REQUESTED_PROTOCOL_VERSION: rmcp::model::ProtocolVersion =
+    rmcp::model::ProtocolVersion::V_2026_07_28;
+
+/// The version the first handshake falls back to when an HTTP server rejects the requested one.
+/// rmcp's `LATEST` and the newest version hosted servers are known to hold a session at.
+const FALLBACK_PROTOCOL_VERSION: rmcp::model::ProtocolVersion =
+    rmcp::model::ProtocolVersion::V_2025_11_25;
+
 /// Monotonic source for [`McpClient::client_id`].
 /// Process-global so every client instance (including test stubs) gets a unique identity.
 static NEXT_CLIENT_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
@@ -3721,8 +3748,39 @@ impl McpClient {
             restore: restore_for_guard,
         };
 
+        // Third clone, for the protocol-version fallback below (HTTP only)
+        let restore_for_fallback = restorable_http_transport(&pending);
+
         let handshake_start = std::time::Instant::now();
-        let mut result = self.try_handshake(pending).await;
+        let mut protocol_version = REQUESTED_PROTOCOL_VERSION;
+        let mut result = self.try_handshake(pending, protocol_version.clone()).await;
+
+        // An HTTP server that cannot hold a session initialised at the requested version gets one
+        // more `initialize`, at the widely-deployed fallback. Spec-wise a server that negotiates
+        // DOWN in its `initialize` reply should then accept requests carrying
+        // `MCP-Protocol-Version: <negotiated>`. GitHub's hosted server
+        // (api.githubcopilot.com/mcp, observed 2026-09-12) answers 200 to a 2026-07-28 `initialize`,
+        // negotiates to 2025-11-25, then rejects every request on that session - starting with
+        // rmcp's own `notifications/initialized` - with `400 invalid session`, so the handshake
+        // fails inside `serve` and the negotiated version is never observable here. Initialising
+        // at 2025-11-25 gives a working session. One extra `initialize`, only after a failure that
+        // is not a timeout; a server that speaks the requested version pays nothing.
+        if let Some(retry_transport) = restore_for_fallback
+            && let Err(err) = &result
+            && !matches!(err, McpError::Timeout { .. })
+        {
+            tracing::info!(
+                server = %self.server_name,
+                requested = REQUESTED_PROTOCOL_VERSION.as_str(),
+                fallback = FALLBACK_PROTOCOL_VERSION.as_str(),
+                error = %err,
+                "MCP handshake failed at the requested protocol version; retrying at the fallback"
+            );
+            protocol_version = FALLBACK_PROTOCOL_VERSION;
+            result = self
+                .try_handshake(retry_transport, protocol_version.clone())
+                .await;
+        }
 
         let handshake_elapsed = handshake_start.elapsed().as_micros() as u64;
         tracing::info!(target: fuigo_telemetry::instrumentation::TARGET, event = "timing", name = "mcp_try_handshake", elapsed_us = handshake_elapsed);
@@ -3749,7 +3807,7 @@ impl McpClient {
                     config: config.clone(),
                     auth_manager: auth_mgr.clone(),
                 };
-                result = self.try_handshake(retry_transport).await;
+                result = self.try_handshake(retry_transport, protocol_version).await;
             }
         }
 
@@ -3829,13 +3887,14 @@ impl McpClient {
     async fn try_handshake(
         &self,
         pending: PendingTransport,
+        protocol_version: rmcp::model::ProtocolVersion,
     ) -> Result<rmcp::service::RunningService<RoleClient, FuigoClientHandler>, McpError> {
         let timeout = std::time::Duration::from_secs(self.startup_timeout_sec);
         let name = &self.server_name;
 
         match pending {
             PendingTransport::Stdio(process) => {
-                let handler = self.make_client_handler();
+                let handler = self.make_client_handler(protocol_version.clone());
                 tokio::time::timeout(timeout, handler.serve(*process))
                     .await
                     .map_err(|_| McpError::timeout(name, timeout))?
@@ -3847,7 +3906,7 @@ impl McpClient {
             PendingTransport::Http(config) => {
                 let transport =
                     Self::build_http_transport(&config, name, self.warn_budget.clone())?;
-                let handler = self.make_client_handler();
+                let handler = self.make_client_handler(protocol_version.clone());
                 tokio::time::timeout(timeout, handler.serve(transport))
                     .await
                     .map_err(|_| McpError::timeout(name, timeout))?
@@ -3908,7 +3967,7 @@ impl McpClient {
                     StreamableHttpClientTransportConfig::with_uri(config.url.as_str());
                 let transport =
                     StreamableHttpClientTransport::with_client(mcp_http_client, transport_config);
-                let handler = self.make_client_handler();
+                let handler = self.make_client_handler(protocol_version.clone());
                 tokio::time::timeout(timeout, handler.serve(transport))
                     .await
                     .map_err(|_| McpError::timeout(name, timeout))?
@@ -3928,7 +3987,7 @@ impl McpClient {
                 );
                 let transport =
                     crate::acp_transport::acp_bridge_transport(server_id, invoker, invoke_timeout);
-                let handler = self.make_client_handler();
+                let handler = self.make_client_handler(protocol_version.clone());
                 tokio::time::timeout(timeout, handler.serve(transport))
                     .await
                     .map_err(|_| McpError::timeout(name, timeout))?
@@ -3940,7 +3999,11 @@ impl McpClient {
         }
     }
 
-    fn make_client_info(server_name: &str, advertise_elicitation: bool) -> ClientInfo {
+    fn make_client_info(
+        server_name: &str,
+        advertise_elicitation: bool,
+        protocol_version: rmcp::model::ProtocolVersion,
+    ) -> ClientInfo {
         use rmcp::model::{
             ElicitationCapability, FormElicitationCapability, UrlElicitationCapability,
         };
@@ -3969,21 +4032,23 @@ impl McpClient {
                 fuigo_version::VERSION.to_string(),
             ),
         )
-        // This pin currently equals rmcp 3.2 LATEST
-        // The explicit setter must remain so a future rmcp bump cannot silently move the wire
-        // 2026-07-28 brings SEP-2322 multi round-trip requests (`input_required` results); older
-        // servers negotiate down and keep the server-initiated `elicitation/create` flow
-        .with_protocol_version(rmcp::model::ProtocolVersion::V_2026_07_28)
+        // `REQUESTED_PROTOCOL_VERSION` on the first handshake; `FALLBACK_PROTOCOL_VERSION` on the
+        // HTTP retry (see `ensure_initialized`)
+        .with_protocol_version(protocol_version)
     }
 
     /// Build the [`FuigoClientHandler`] that drives `client.serve(...)`.
     ///
     /// The handler holds a **clone of `Arc<Mutex<Option<Sender>>>`**, not a snapshot, so a later [`Self::set_event_tx`] reaches the live handler.
-    fn make_client_handler(&self) -> FuigoClientHandler {
+    fn make_client_handler(
+        &self,
+        protocol_version: rmcp::model::ProtocolVersion,
+    ) -> FuigoClientHandler {
         FuigoClientHandler {
             info: Self::make_client_info(
                 &self.server_name,
                 !self.is_acp() && self.elicitation_tx.lock().is_some(),
+                protocol_version,
             ),
             server_name: self.server_name.clone(),
             notify_tx: Arc::clone(&self.notify_tx),

--- a/crates/codegen/fuigo-mcp/src/servers_tests.rs
+++ b/crates/codegen/fuigo-mcp/src/servers_tests.rs
@@ -1937,6 +1937,146 @@ fn event_types(jsonl: &str) -> Vec<serde_json::Value> {
         .collect()
 }
 
+// ── Protocol-version downgrade (GitHub-shaped server) ────────────────────────
+
+/// Mirrors api.githubcopilot.com/mcp as observed 2026-09-12: `initialize` at a version newer than
+/// 2025-11-25 is answered 200 with `protocolVersion: 2025-11-25`, but the session is bound to the
+/// version the client REQUESTED - every later request whose `mcp-protocol-version` header differs
+/// from that (rmcp sends the negotiated one, starting with `notifications/initialized`) is
+/// `400 invalid session`. Initialising at 2025-11-25 (or older) gives a working session.
+#[derive(Clone, Default)]
+struct GithubLikeHandles {
+    /// `protocolVersion` of every `initialize`, in order.
+    init_versions: Arc<parking_lot::Mutex<Vec<String>>>,
+    /// session id -> the version that session was initialised WITH (not the negotiated one).
+    sessions: Arc<parking_lot::Mutex<std::collections::HashMap<String, String>>>,
+    rejected: Arc<AtomicUsize>,
+}
+
+const GITHUB_LIKE_MAX_VERSION: &str = "2025-11-25";
+
+async fn github_like_handle_post(
+    axum::extract::State(handles): axum::extract::State<GithubLikeHandles>,
+    headers: axum::http::HeaderMap,
+    axum::Json(req): axum::Json<serde_json::Value>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    let id = req["id"].clone();
+    let header = |name: &str| {
+        headers
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned)
+    };
+    if req["method"].as_str() == Some("initialize") {
+        let requested = req["params"]["protocolVersion"]
+            .as_str()
+            .unwrap_or_default()
+            .to_owned();
+        let negotiated = if requested.as_str() > GITHUB_LIKE_MAX_VERSION {
+            GITHUB_LIKE_MAX_VERSION.to_owned()
+        } else {
+            requested.clone()
+        };
+        let session = format!("s{}", handles.init_versions.lock().len() + 1);
+        handles.init_versions.lock().push(requested.clone());
+        handles.sessions.lock().insert(session.clone(), requested);
+        let result = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {
+                "protocolVersion": negotiated,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "github-like", "version": "0.0.0"},
+            },
+        });
+        return ([("mcp-session-id", session)], axum::Json(result)).into_response();
+    }
+    let bound_version =
+        header("mcp-session-id").and_then(|s| handles.sessions.lock().get(&s).cloned());
+    if bound_version.is_none() || bound_version != header("mcp-protocol-version") {
+        handles.rejected.fetch_add(1, Ordering::Relaxed);
+        return (axum::http::StatusCode::BAD_REQUEST, "invalid session").into_response();
+    }
+    match req["method"].as_str() {
+        Some("tools/list") => axum::Json(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {"tools": [{"name": "get_me", "inputSchema": {"type": "object"}}]},
+        }))
+        .into_response(),
+        _ => axum::http::StatusCode::ACCEPTED.into_response(),
+    }
+}
+
+async fn spawn_github_like_mcp() -> (String, GithubLikeHandles) {
+    let handles = GithubLikeHandles::default();
+    let app = axum::Router::new()
+        .route(
+            "/mcp",
+            axum::routing::get(|| async { axum::http::StatusCode::METHOD_NOT_ALLOWED })
+                .post(github_like_handle_post),
+        )
+        .with_state(handles.clone());
+    (spawn_test_http_server(app).await, handles)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_handshake_falls_back_to_the_previous_protocol_version_when_the_server_rejects_the_session()
+ {
+    let (url, handles) = spawn_github_like_mcp().await;
+    let client = fake_http_client(&url, 5);
+    let service = client.ensure_initialized().await.expect("handshake");
+
+    // First initialise at the requested version (whose session the server then rejects), second
+    // at the fallback.
+    assert_eq!(
+        *handles.init_versions.lock(),
+        vec![
+            REQUESTED_PROTOCOL_VERSION.as_str().to_owned(),
+            FALLBACK_PROTOCOL_VERSION.as_str().to_owned()
+        ]
+    );
+    assert_eq!(FALLBACK_PROTOCOL_VERSION.as_str(), GITHUB_LIKE_MAX_VERSION);
+    assert!(
+        handles.rejected.load(Ordering::Relaxed) >= 1,
+        "the first session must have been rejected"
+    );
+    assert_eq!(
+        service
+            .peer_info()
+            .map(|info| info.protocol_version.as_str().to_owned()),
+        Some(GITHUB_LIKE_MAX_VERSION.to_owned())
+    );
+    // The live session is the second one: its requests carry the version it was initialised
+    // with, so the server accepts them. Without the fallback the handshake itself fails.
+    let tools = service
+        .list_tools(None)
+        .await
+        .expect("tools/list on the re-initialised session");
+    assert_eq!(
+        tools
+            .tools
+            .iter()
+            .map(|t| t.name.as_ref())
+            .collect::<Vec<_>>(),
+        vec!["get_me"]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_handshake_initialises_once_when_the_server_speaks_the_requested_version() {
+    // The stock fake echoes the requested version back: no downgrade, no second `initialize`.
+    let (url, handles) = spawn_fake_mcp(CallToolBehavior::HangThenOk { hang_ms: 0 }).await;
+    let client = fake_http_client(&url, 5);
+    client.ensure_initialized().await.expect("handshake");
+    assert_eq!(handles.inits.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        handles.init_version.lock().as_deref(),
+        Some(REQUESTED_PROTOCOL_VERSION.as_str())
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn http_transport_sends_default_user_agent_on_initialize() {
     let (url, handles) = spawn_fake_mcp(CallToolBehavior::HangThenOk { hang_ms: 0 }).await;
@@ -2556,7 +2696,11 @@ async fn try_call_tool_reconnects_then_succeeds_after_retriable_transport_error(
             }
         });
         let handler = FuigoClientHandler {
-            info: McpClient::make_client_info("dead", /* advertise_elicitation */ true),
+            info: McpClient::make_client_info(
+                "dead",
+                /* advertise_elicitation */ true,
+                REQUESTED_PROTOCOL_VERSION,
+            ),
             server_name: "dead".to_string(),
             notify_tx: Arc::new(parking_lot::Mutex::new(None)),
             elicitation_tx: Arc::new(parking_lot::Mutex::new(None)),
@@ -2666,7 +2810,11 @@ async fn watched_live_client(name: &str) -> Arc<McpClient> {
         }
     });
     let handler = FuigoClientHandler {
-        info: McpClient::make_client_info(name, /* advertise_elicitation */ true),
+        info: McpClient::make_client_info(
+            name,
+            /* advertise_elicitation */ true,
+            REQUESTED_PROTOCOL_VERSION,
+        ),
         server_name: name.to_string(),
         notify_tx: Arc::new(parking_lot::Mutex::new(None)),
         elicitation_tx: Arc::new(parking_lot::Mutex::new(None)),
@@ -3247,14 +3395,23 @@ async fn is_healthy_pending_does_not_block_on_handshake() {
 #[test]
 fn make_client_info_pins_protocol_version() {
     assert_eq!(
-        McpClient::make_client_info("test-srv", /* advertise_elicitation */ true).protocol_version,
+        McpClient::make_client_info(
+            "test-srv",
+            /* advertise_elicitation */ true,
+            REQUESTED_PROTOCOL_VERSION
+        )
+        .protocol_version,
         rmcp::model::ProtocolVersion::V_2026_07_28
     );
 }
 
 #[test]
 fn make_client_info_advertises_form_and_url_elicitation() {
-    let info = McpClient::make_client_info("test-srv", /* advertise_elicitation */ true);
+    let info = McpClient::make_client_info(
+        "test-srv",
+        /* advertise_elicitation */ true,
+        REQUESTED_PROTOCOL_VERSION,
+    );
     let elicitation = info
         .capabilities
         .elicitation
@@ -3300,7 +3457,9 @@ fn acp_zero_ipc_client_info_does_not_advertise_elicitation() {
         None,
         None,
     );
-    let acp_info = acp.make_client_handler().get_info();
+    let acp_info = acp
+        .make_client_handler(REQUESTED_PROTOCOL_VERSION)
+        .get_info();
     assert!(
         acp_info.capabilities.elicitation.is_none(),
         "ACP zero-IPC cannot deliver elicitation/create"
@@ -3309,7 +3468,7 @@ fn acp_zero_ipc_client_info_does_not_advertise_elicitation() {
     let no_bridge = McpClient::stub("stdio");
     assert!(
         no_bridge
-            .make_client_handler()
+            .make_client_handler(REQUESTED_PROTOCOL_VERSION)
             .get_info()
             .capabilities
             .elicitation
@@ -3320,7 +3479,7 @@ fn acp_zero_ipc_client_info_does_not_advertise_elicitation() {
     let hitl = McpClient::stub("stdio");
     hitl.set_elicitation_tx(Some(crate::elicitation::ElicitationInbox::new()));
     assert!(
-        hitl.make_client_handler()
+        hitl.make_client_handler(REQUESTED_PROTOCOL_VERSION)
             .get_info()
             .capabilities
             .elicitation
@@ -3333,7 +3492,11 @@ fn acp_zero_ipc_client_info_does_not_advertise_elicitation() {
 async fn client_handler_routes_tools_changed() {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<McpClientEvent>();
     let handler = FuigoClientHandler {
-        info: McpClient::make_client_info("test", /* advertise_elicitation */ true),
+        info: McpClient::make_client_info(
+            "test",
+            /* advertise_elicitation */ true,
+            REQUESTED_PROTOCOL_VERSION,
+        ),
         server_name: "test".to_string(),
         notify_tx: Arc::new(parking_lot::Mutex::new(Some(tx))),
         elicitation_tx: Arc::new(parking_lot::Mutex::new(None)),
@@ -3353,7 +3516,7 @@ async fn client_handler_observes_post_handshake_set_event_tx() {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<McpClientEvent>();
     let client = Arc::new(McpClient::stub("test"));
 
-    let handler = client.make_client_handler();
+    let handler = client.make_client_handler(REQUESTED_PROTOCOL_VERSION);
 
     assert!(handler.notify_tx.lock().is_none());
 


### PR DESCRIPTION
## Problem

Hosted HTTP MCP servers that cannot hold a session initialised at the newest protocol version never connect. Seen with GitHub's server (api.githubcopilot.com/mcp): Fuigo initialises at 2026-07-28, GitHub answers 200 and negotiates the version down to 2025-11-25, then rejects every request on that session - starting with rmcp's own notifications/initialized - with 400 invalid session. The session is bound to the version the client REQUESTED (and requests at that version need a draft-spec _meta field). rmcp does the spec-correct thing and sends MCP-Protocol-Version: <negotiated>, so the handshake dies inside serve and the negotiated version is never observable.

Under Wayland Desktop the GitHub connector therefore registered zero tools on 1.0.13 and 1.0.14 alike (fuigo log: worker quit with fatal: unexpected server response: HTTP 400 Bad Request: invalid session). Proven with curl against GitHub: initialise at 2025-06-18 or 2025-11-25 -> tools/list 200; at 2026-07-28 -> 400 invalid session on every follow-up.

## Change

ensure_initialized retries the handshake once at FALLBACK_PROTOCOL_VERSION (2025-11-25, rmcp's LATEST) when the first handshake fails on an HTTP transport with anything but a timeout. Stdio has no server-side session and the ACP bridge is in-process, so they are untouched. A server that speaks 2026-07-28 pays nothing and keeps SEP-2322. The existing token-refresh retry reuses whichever version last ran, so an expired token on a downgrading server still recovers.

make_client_info / make_client_handler / try_handshake take the protocol version explicitly; REQUESTED_PROTOCOL_VERSION keeps the 2026-07-28 pin and the rationale that was on the setter.

## Why this is safe for Murage

Murage's four servers (agents, browser, composio, computer) are unaffected unless one of them rejects a 2026-07-28 session, in which case it starts working instead of failing. Nothing changes for a server whose first handshake succeeds: the retry is only reached from the Err arm, and the stock fake (which echoes the requested version) is pinned to exactly one initialize.

## Tests

- spawn_github_like_mcp: a fake that binds each session to the version it was initialised with and 400s every request whose MCP-Protocol-Version differs.
- http_handshake_falls_back_to_the_previous_protocol_version_when_the_server_rejects_the_session: two initializes (2026-07-28 then 2025-11-25), at least one rejection, tools/list works on the second session. Fails with the fallback disabled (mutation-checked).
- http_handshake_initialises_once_when_the_server_speaks_the_requested_version: no downgrade, exactly one initialize.
- cargo test -p fuigo-mcp: 219 passed, 0 failed. rustfmt clean on the two touched files.

Live, real GitHub MCP with a gh token, interleaved shipped 1.0.14 vs this build:

| build | get_me via the GitHub MCP |
|---|---|
| shipped 1.0.14 | "GitHub MCP server failed to connect", 2/2 |
| this branch | tool called, answers FerroxLabs, 2/2 |

## Follow-up (not in this PR)

Tool names longer than 64 characters are still dropped at registration (tool name '...' reason in the log): 58 of the Google Workspace connector's tools under a reverse-DNS server name. Same fix shape as #10 (project the name; truncate + short hash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvuJEwapJMLSJ7BCaSbeuW
