### PR TITLE
Fuigo 1.0.15: GitHub-hosted MCP protocol fallback + 64-char tool-name projection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "fuigo-version"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "semver",
 ]

--- a/crates/codegen/fuigo-pager/npm/fuigo-darwin-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/darwin-arm64",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "description": "darwin-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-darwin-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/darwin-x64",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "description": "darwin-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-linux-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/linux-arm64",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "description": "linux-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-linux-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/linux-x64",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "description": "linux-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-win32-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/win32-arm64",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "description": "win32-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-win32-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/win32-x64",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "description": "win32-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fuigo",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "description": "Bring Fuigo into your terminal",
     "license": "Apache-2.0",
     "bin": {
@@ -40,11 +40,11 @@
         "@iarna/toml": "^3.0.0"
     },
     "optionalDependencies": {
-        "@fuigo/darwin-arm64": "1.0.14",
-        "@fuigo/darwin-x64": "1.0.14",
-        "@fuigo/linux-arm64": "1.0.14",
-        "@fuigo/linux-x64": "1.0.14",
-        "@fuigo/win32-arm64": "1.0.14",
-        "@fuigo/win32-x64": "1.0.14"
+        "@fuigo/darwin-arm64": "1.0.15",
+        "@fuigo/darwin-x64": "1.0.15",
+        "@fuigo/linux-arm64": "1.0.15",
+        "@fuigo/linux-x64": "1.0.15",
+        "@fuigo/win32-arm64": "1.0.15",
+        "@fuigo/win32-x64": "1.0.15"
     }
 }

--- a/crates/codegen/fuigo-version/Cargo.toml
+++ b/crates/codegen/fuigo-version/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 license = "Apache-2.0"
 name = "fuigo-version"
-version = "1.0.14"
+version = "1.0.15"
 edition.workspace = true
 description = "Lockstepped fuigo CLI version."
 


### PR DESCRIPTION
Release 1.0.15. Version bump only (same nine files as #11); the fixes are already on main.

- #12 (22fc1c5): Streamable-HTTP MCP handshake falls back to protocol 2025-11-25 when the server accepts initialize at 2026-07-28 but then rejects the session with HTTP 400. Fixes hosted GitHub MCP (api.githubcopilot.com/mcp), which never connected on 1.0.13/1.0.14.
- #13 (313dfa1): qualified MCP tool names are projected onto the 64-char provider function-name limit (truncate + short hash) instead of being skipped. Fixes 58 of Google Workspace's tools being dropped with "Skipping MCP tool with invalid name".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvuJEwapJMLSJ7BCaSbeuW
