### PR TITLE
fix(compat): switch for the ~/.agents/skills scan (FUIGO_AGENTS_SKILLS_ENABLED)

### DIFF
--- a/crates/codegen/fuigo-agent/src/prompt/skills.rs
+++ b/crates/codegen/fuigo-agent/src/prompt/skills.rs
@@ -62,7 +62,7 @@ pub struct SkillsConfig {
 ///
 /// When `working_directory` is `None`, only User-scoped skills are returned.
 ///
-/// `compat` gates which vendor (`.claude`/`.cursor`) dirs are scanned.
+/// `compat` gates which vendor (`.agents`/`.claude`/`.cursor`) dirs are scanned.
 /// Pass `CompatConfig::default()` to preserve the historical all-vendors behavior.
 /// `project_trusted` is the folder-trust verdict for `working_directory`; when false, the project chain and the workspace-user overlay are omitted.
 pub async fn list_skills(
@@ -211,7 +211,7 @@ fn collect_skill_config_dirs_from_sources(
         }
     };
 
-    // Vendor dirs (`.claude`/`.cursor`) are gated by the resolved compat config; `.fuigo` and `.agents` are always present
+    // `.agents`/`.claude`/`.cursor` are gated by the resolved compat config; `.fuigo` is always present
     // When all cells are on, this list equals the historical `[".fuigo", ".agents", ".claude", ".cursor"]`
     let config_dir_names = compat.skill_config_dirs();
 
@@ -225,10 +225,12 @@ fn collect_skill_config_dirs_from_sources(
     }
 
     // Priority 3: Global user dirs. `.fuigo` comes from `fuigo_home` (which may be overridden), so it's handled separately.
-    // `.agents` is always added, while `.claude`/`.cursor` are gated by the skills compat cells
+    // `.agents`/`.claude`/`.cursor` are gated by their skills compat cells
     try_add(fuigo_home);
     if let Some(home) = fuigo_dirs::home_dir() {
-        try_add(home.join(".agents"));
+        if compat.agents.skills {
+            try_add(home.join(".agents"));
+        }
         if compat.claude.skills {
             try_add(home.join(".claude"));
         }
@@ -2508,6 +2510,62 @@ mod tests {
         );
         assert!(ends_with(&dirs, ".claude"), "claude must remain: {dirs:?}");
         assert!(ends_with(&dirs, ".fuigo"), "fuigo must remain: {dirs:?}");
+    }
+
+    /// RAII guard: set an env var, restore the prior value (or unset) on drop.
+    struct EnvVarGuard {
+        key: &'static str,
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let prev = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value) };
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.prev.take() {
+                Some(v) => unsafe { std::env::set_var(self.key, v) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    #[test]
+    #[serial_test::serial(home_env)]
+    fn collect_skill_config_dirs_gates_home_agents_dir() {
+        // Pin both HOME and USERPROFILE so Windows home_dir() sees the tempdir too
+        let home = tempfile::tempdir().unwrap();
+        let _home_guard = EnvVarGuard::set("HOME", home.path());
+        let _userprofile_guard = EnvVarGuard::set("USERPROFILE", home.path());
+        let home_agents = home.path().join(".agents");
+        fs::create_dir_all(home_agents.join("skills")).unwrap();
+        let fuigo_home = tempfile::tempdir().unwrap();
+
+        let canon = |p: &Path| dunce::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+        let has_home_agents =
+            |dirs: &[PathBuf]| dirs.iter().any(|d| canon(d) == canon(&home_agents));
+
+        // Default ON: `~/.agents` is scanned (historical CLI behavior)
+        let dirs =
+            collect_skill_config_dirs(None, None, fuigo_home.path(), &[], CompatConfig::default());
+        assert!(
+            has_home_agents(&dirs),
+            "~/.agents must be scanned by default: {dirs:?}"
+        );
+
+        // `agents.skills = false` (FUIGO_AGENTS_SKILLS_ENABLED=0): `~/.agents` is not scanned
+        let mut compat = CompatConfig::default();
+        compat.agents.skills = false;
+        let dirs = collect_skill_config_dirs(None, None, fuigo_home.path(), &[], compat);
+        assert!(
+            !has_home_agents(&dirs),
+            "~/.agents must be gated off: {dirs:?}"
+        );
     }
 
     // ── Same-scope frontmatter-name collisions (copied skill dirs) ──────

--- a/crates/codegen/fuigo-pager/docs/user-guide/05-configuration.md
+++ b/crates/codegen/fuigo-pager/docs/user-guide/05-configuration.md
@@ -376,7 +376,7 @@ disabled = ["wip-skill"]              # skill names to keep listed but inactive
 
 ### Harness compatibility
 
-Control vendor compatibility for Cursor, Claude, and Codex. Every cell defaults to `true`. Session cells stay staged and inert until a foreign-session scanner consumes them, and each tool needs both its `sessions` cell and the matching `resume-claude`, `resume-codex`, or `resume-cursor` skill — a missing skill means zero foreign-session filesystem I/O.
+Control vendor compatibility for Cursor, Claude, Codex, and the vendor-neutral `.agents/` directory. Every cell defaults to `true`. Session cells stay staged and inert until a foreign-session scanner consumes them, and each tool needs both its `sessions` cell and the matching `resume-claude`, `resume-codex`, or `resume-cursor` skill — a missing skill means zero foreign-session filesystem I/O.
 
 ```toml
 [compat.cursor]
@@ -397,9 +397,12 @@ sessions = true   # staged; no scanner consumer yet
 
 [compat.codex]
 sessions = true   # staged; no scanner consumer yet
+
+[compat.agents]
+skills = true     # scan ~/.agents/skills/ and <dir>/.agents/skills/ (vendor-neutral layout)
 ```
 
-Codex's `skills`, `rules`, `agents`, `mcps`, and `hooks` cells are reserved and currently inert — they do not enable `.codex` discovery.
+Codex's `skills`, `rules`, `agents`, `mcps`, and `hooks` cells are reserved and currently inert — they do not enable `.codex` discovery. The `agents` vendor is the vendor-neutral `.agents/` directory; only its `skills` cell is consumed (`FUIGO_AGENTS_SKILLS_ENABLED`).
 
 For Claude and Cursor, `rules` and `agents` are independent: turning off named instruction files doesn't disable the home or project rules directory, and turning off rules doesn't disable named files. Claude's `agents` cell gates home-level `~/.claude/` named files and project `<dir>/.claude/CLAUDE*.md`; generic top-level `Claude.md`, `CLAUDE.md`, and `CLAUDE.local.md` stay recognized. Project rule paths are scanned at every directory from the repo root down to the current one.
 

--- a/crates/codegen/fuigo-pager/docs/user-guide/08-skills.md
+++ b/crates/codegen/fuigo-pager/docs/user-guide/08-skills.md
@@ -32,7 +32,7 @@ Flat `*.md` files under a `commands/` directory become user-invocable slash comm
 
 Skill and command discovery does **not** use `.gitignore`. Paths under known skill roots (`.fuigo/`, `.agents/`, `.claude/`, `.cursor/`) always load when present on disk — teams often ignore `.claude/**` as local-only config while still expecting `/frontend`-style project commands to work. To hide a skill, use `[skills] ignore` in config (not repo ignore rules).
 
-Fuigo scans the Claude and Cursor skill directories by default. To stop scanning a vendor, set its `skills` cell to `false` under `[compat.cursor]` or `[compat.claude]` in `~/.fuigo/config.toml`, or set the `FUIGO_CURSOR_SKILLS_ENABLED` or `FUIGO_CLAUDE_SKILLS_ENABLED` environment variable to `false`. See [Configuration](05-configuration.md#harness-compatibility) for details. Fuigo always filters out known vendor-shipped default skills (such as Cursor's `shell`, `canvas`, and `statusline`), regardless of these settings.
+Fuigo scans the Claude, Cursor, and vendor-neutral `.agents/` skill directories by default. To stop scanning one, set its `skills` cell to `false` under `[compat.cursor]`, `[compat.claude]`, or `[compat.agents]` in `~/.fuigo/config.toml`, or set the `FUIGO_CURSOR_SKILLS_ENABLED`, `FUIGO_CLAUDE_SKILLS_ENABLED`, or `FUIGO_AGENTS_SKILLS_ENABLED` environment variable to `false`. See [Configuration](05-configuration.md#harness-compatibility) for details. Fuigo always filters out known vendor-shipped default skills (such as Cursor's `shell`, `canvas`, and `statusline`), regardless of these settings.
 
 ### Additional Skill Directories
 

--- a/crates/codegen/fuigo-pager/docs/user-guide/26-config-reference.md
+++ b/crates/codegen/fuigo-pager/docs/user-guide/26-config-reference.md
@@ -114,6 +114,7 @@ User-level configuration lives in `$FUIGO_HOME/config.toml` (default `~/.fuigo/c
 
 | Key | Type / Values | Requirements | Managed | Details |
 | --- | --- | --- | --- | --- |
+| `compat.agents.skills` | `boolean` | `yes` | `user` | Scan the vendor-neutral `.agents/skills/` directories. Also FUIGO_AGENTS_SKILLS_ENABLED. |
 | `compat.claude.agents` | `boolean` | `yes` | `user` | Scan CLAUDE.md. Also FUIGO_CLAUDE_AGENTS_ENABLED. |
 | `compat.claude.hooks` | `boolean` | `yes` | `user` | Scan Claude hooks. Also FUIGO_CLAUDE_HOOKS_ENABLED. |
 | `compat.claude.mcps` | `boolean` | `yes` | `user` | Scan Claude MCP config. Also FUIGO_CLAUDE_MCPS_ENABLED. |

--- a/crates/codegen/fuigo-shell/src/agent/config.rs
+++ b/crates/codegen/fuigo-shell/src/agent/config.rs
@@ -824,6 +824,7 @@ pub fn resolve_compat_sessions_from_raw(
             CompatVendor::Cursor => config.cursor.sessions = value,
             CompatVendor::Claude => config.claude.sessions = value,
             CompatVendor::Codex => config.codex.sessions = value,
+            CompatVendor::Agents => config.agents.sessions = value,
         }
     }
     resolve_compat_config(&config, remote)

--- a/crates/codegen/fuigo-shell/src/agent/config_tests.rs
+++ b/crates/codegen/fuigo-shell/src/agent/config_tests.rs
@@ -6349,6 +6349,34 @@ fn resolve_compat_env_sessions_disable_independently() {
 }
 #[test]
 #[serial]
+fn resolve_compat_agents_skills_env_and_toml() {
+    let _env = isolate_compat_env();
+    // Default ON: the `~/.agents/skills` scan stays on for CLI users.
+    assert!(
+        resolve_compat_config(&CompatConfigToml::default(), None)
+            .agents
+            .skills
+    );
+
+    // `[compat.agents] skills = false` turns it off; other skills cells are untouched.
+    let config = parse_compat("[compat.agents]\nskills = false");
+    let resolved = resolve_compat_config(&config, None);
+    assert!(!resolved.agents.skills);
+    assert!(resolved.claude.skills && resolved.cursor.skills);
+
+    // The env var wins over TOML in both directions.
+    let _on = EnvGuard::set("FUIGO_AGENTS_SKILLS_ENABLED", "true");
+    assert!(resolve_compat_config(&config, None).agents.skills);
+    drop(_on);
+    let _off = EnvGuard::set("FUIGO_AGENTS_SKILLS_ENABLED", "false");
+    assert!(
+        !resolve_compat_config(&CompatConfigToml::default(), None)
+            .agents
+            .skills
+    );
+}
+#[test]
+#[serial]
 fn resolve_compat_precedence_and_reserved_codex_hook() {
     let _env = isolate_compat_env();
     let config = parse_compat("[compat.cursor]\nsessions = false\n[compat.codex]\nhooks = false");

--- a/crates/codegen/fuigo-shell/src/inspect/compat.rs
+++ b/crates/codegen/fuigo-shell/src/inspect/compat.rs
@@ -199,7 +199,7 @@ mod tests {
         let report = resolve_without_env(Ok(&effective_config));
 
         assert!(!report.remote_settings_loaded);
-        assert_eq!(report.cells.len(), 13);
+        assert_eq!(report.cells.len(), 14);
         assert!(
             report
                 .cells

--- a/crates/codegen/fuigo-tools/src/implementations/skills/discovery.rs
+++ b/crates/codegen/fuigo-tools/src/implementations/skills/discovery.rs
@@ -829,7 +829,8 @@ pub fn parse_skill_files(skill_files: Vec<(PathBuf, SkillScope)>) -> Vec<SkillIn
 ///
 /// For each path in `file_paths`, walks from `dirname(path)` upward toward
 /// `cwd` (exclusive). At each directory, checks for `.fuigo/skills/`,
-/// `.agents/skills/`, and (gated on `compat.claude.skills`) `.claude/skills/`.
+/// (gated on `compat.agents.skills`) `.agents/skills/`, and (gated on
+/// `compat.claude.skills`) `.claude/skills/`.
 /// Skips already-checked dirs.
 ///
 /// Skill/command roots are **not** filtered by `.gitignore`. Discovery only
@@ -852,9 +853,12 @@ pub fn discover_skills_for_paths(
     already_checked: &mut HashSet<PathBuf>,
     compat: CompatConfig,
 ) -> Vec<SkillInfo> {
-    // `.fuigo` and `.agents` are always scanned; `.claude` is gated on the
-    // claude-vendor skills cell. (`.cursor` is excluded here by design — see fn docs.)
-    let mut config_dir_names: Vec<&str> = vec![".fuigo", ".agents"];
+    // `.fuigo` is always scanned; `.agents` and `.claude` are gated on their
+    // skills cells. (`.cursor` is excluded here by design — see fn docs.)
+    let mut config_dir_names: Vec<&str> = vec![".fuigo"];
+    if compat.agents.skills {
+        config_dir_names.push(".agents");
+    }
     if compat.claude.skills {
         config_dir_names.push(".claude");
     }

--- a/crates/codegen/fuigo-tools/src/types/compat.rs
+++ b/crates/codegen/fuigo-tools/src/types/compat.rs
@@ -12,6 +12,11 @@
 //!   cell is `Option<bool>` so `None` falls through to the resolution chain.
 //! - [`CompatConfig`] — resolved plain bools consumed at runtime. Every cell
 //!   defaults on.
+//!
+//! The vendor-neutral `.agents` directory (the cross-agent skills layout) is
+//! registered as its own vendor with a single runtime cell, `agents.skills`,
+//! so an embedder can turn the `~/.agents/skills` scan off the same way it
+//! turns off `~/.claude/skills` or `~/.cursor/skills`.
 
 use serde::{Deserialize, Serialize};
 
@@ -20,6 +25,8 @@ pub enum CompatVendor {
     Cursor,
     Claude,
     Codex,
+    /// The vendor-neutral `.agents` directory shared across agent tools.
+    Agents,
 }
 
 impl CompatVendor {
@@ -28,6 +35,7 @@ impl CompatVendor {
             Self::Cursor => "cursor",
             Self::Claude => "claude",
             Self::Codex => "codex",
+            Self::Agents => "agents",
         }
     }
 }
@@ -119,11 +127,12 @@ impl CompatCell {
         match self.vendor {
             CompatVendor::Cursor | CompatVendor::Claude => true,
             CompatVendor::Codex => matches!(self.surface, CompatSurface::Sessions),
+            CompatVendor::Agents => matches!(self.surface, CompatSurface::Skills),
         }
     }
 }
 
-pub const COMPAT_CELLS: [CompatCell; 18] = [
+pub const COMPAT_CELLS: [CompatCell; 19] = [
     CompatCell::new(
         CompatVendor::Cursor,
         CompatSurface::Skills,
@@ -232,6 +241,12 @@ pub const COMPAT_CELLS: [CompatCell; 18] = [
         "FUIGO_CODEX_SESSIONS_ENABLED",
         Some(CompatRemoteKey::CodexSessions),
     ),
+    CompatCell::new(
+        CompatVendor::Agents,
+        CompatSurface::Skills,
+        "FUIGO_AGENTS_SKILLS_ENABLED",
+        None,
+    ),
 ];
 
 /// Raw per-vendor compat cells parsed from `[compat.<vendor>]` TOML.
@@ -269,6 +284,9 @@ pub struct CompatConfigToml {
     pub claude: VendorCompatToml,
     #[serde(default)]
     pub codex: VendorCompatToml,
+    /// `[compat.agents]`: only `skills` is consumed at runtime.
+    #[serde(default)]
+    pub agents: VendorCompatToml,
 }
 
 impl CompatConfigToml {
@@ -277,6 +295,7 @@ impl CompatConfigToml {
             CompatVendor::Cursor => self.cursor.value(cell.surface()),
             CompatVendor::Claude => self.claude.value(cell.surface()),
             CompatVendor::Codex => self.codex.value(cell.surface()),
+            CompatVendor::Agents => self.agents.value(cell.surface()),
         }
     }
 }
@@ -331,13 +350,15 @@ impl Default for VendorCompat {
 
 /// Resolved `[compat]` configuration threaded into compatibility consumers.
 ///
-/// Every cell defaults on. Codex's non-session cells are reserved and are not
-/// consumed by discovery.
+/// Every cell defaults on. Codex's non-session cells and the non-skills
+/// `agents` cells are reserved and are not consumed by discovery.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CompatConfig {
     pub cursor: VendorCompat,
     pub claude: VendorCompat,
     pub codex: VendorCompat,
+    /// Vendor-neutral `.agents` directory; only `skills` is consumed.
+    pub agents: VendorCompat,
 }
 
 impl CompatConfig {
@@ -346,6 +367,7 @@ impl CompatConfig {
             CompatVendor::Cursor => self.cursor.value(cell.surface()),
             CompatVendor::Claude => self.claude.value(cell.surface()),
             CompatVendor::Codex => self.codex.value(cell.surface()),
+            CompatVendor::Agents => self.agents.value(cell.surface()),
         }
     }
 
@@ -354,18 +376,22 @@ impl CompatConfig {
             CompatVendor::Cursor => self.cursor.set(cell.surface(), value),
             CompatVendor::Claude => self.claude.set(cell.surface(), value),
             CompatVendor::Codex => self.codex.set(cell.surface(), value),
+            CompatVendor::Agents => self.agents.set(cell.surface(), value),
         }
     }
 
     /// Config directories that may contain `skills/` subdirectories, in
-    /// priority order. `.fuigo` and `.agents` are always included; `.claude`
+    /// priority order. `.fuigo` is always included; `.agents`, `.claude`
     /// and `.cursor` are gated on their respective `skills` cell.
     ///
     /// Replaces the hard-coded `[".fuigo", ".agents", ".claude", ".cursor"]`
     /// in `collect_skill_config_dirs`. When all cells are on, the returned
     /// list is identical to the historical constant.
     pub fn skill_config_dirs(&self) -> Vec<&'static str> {
-        let mut dirs = vec![".fuigo", ".agents"];
+        let mut dirs = vec![".fuigo"];
+        if self.agents.skills {
+            dirs.push(".agents");
+        }
         if self.claude.skills {
             dirs.push(".claude");
         }
@@ -467,6 +493,7 @@ mod tests {
                 ("codex", "mcps", None),
                 ("codex", "hooks", None),
                 ("codex", "sessions", Some(CodexSessions)),
+                ("agents", "skills", None),
             ]
         );
 
@@ -479,7 +506,12 @@ mod tests {
                 cell.surface().as_str()
             );
         }
-        for vendor in [defaults.cursor, defaults.claude, defaults.codex] {
+        for vendor in [
+            defaults.cursor,
+            defaults.claude,
+            defaults.codex,
+            defaults.agents,
+        ] {
             assert!(vendor.skills && vendor.rules && vendor.agents);
             assert!(vendor.mcps && vendor.hooks);
             assert!(vendor.sessions);
@@ -505,6 +537,7 @@ mod tests {
                 ("claude", "hooks"),
                 ("claude", "sessions"),
                 ("codex", "sessions"),
+                ("agents", "skills"),
             ]
         );
     }
@@ -531,6 +564,27 @@ mod tests {
         let mut c2 = CompatConfig::default();
         c2.claude.skills = false;
         assert_eq!(c2.skill_config_dirs(), vec![".fuigo", ".agents", ".cursor"]);
+    }
+
+    #[test]
+    fn agents_skills_cell_gates_dot_agents_dir() {
+        // Default ON keeps the historical `.agents` scan for CLI users.
+        assert!(
+            CompatConfig::default()
+                .skill_config_dirs()
+                .contains(&".agents")
+        );
+
+        // `agents.skills = false` (FUIGO_AGENTS_SKILLS_ENABLED / `[compat.agents]`)
+        // drops `.agents` and leaves every other root untouched.
+        let mut c = CompatConfig::default();
+        c.agents.skills = false;
+        assert_eq!(c.skill_config_dirs(), vec![".fuigo", ".claude", ".cursor"]);
+
+        // Off with the vendor cells also off: only the native root remains.
+        c.claude.skills = false;
+        c.cursor.skills = false;
+        assert_eq!(c.skill_config_dirs(), vec![".fuigo"]);
     }
 
     #[test]
@@ -628,5 +682,12 @@ mod tests {
         assert_eq!(parsed.claude.sessions, None);
         assert_eq!(parsed.cursor, VendorCompatToml::default());
         assert_eq!(parsed.codex, VendorCompatToml::default());
+        assert_eq!(parsed.agents, VendorCompatToml::default());
+
+        // `[compat.agents] skills = false` parses into the agents vendor cell.
+        let parsed: CompatConfigToml = serde_yaml::from_str("agents:\n  skills: false\n").unwrap();
+        assert_eq!(parsed.agents.skills, Some(false));
+        assert_eq!(parsed.agents.rules, None);
+        assert_eq!(parsed.claude, VendorCompatToml::default());
     }
 }


### PR DESCRIPTION
Fixes #15

Skill discovery scanned the vendor-neutral .agents directory unconditionally (home ~/.agents/skills, the project chain, and the dynamic file-path walk). Under a managed FUIGO_HOME that already turned the 18 compat cells off, every skill the user had under ~/.agents still loaded.

This registers .agents as its own compat vendor with one runtime cell, expressed the same way as the existing cells:

- env: FUIGO_AGENTS_SKILLS_ENABLED
- TOML: [compat.agents] skills = false
- resolution: env > TOML > default; default ON (CLI behaviour unchanged)

All three .agents scan sites read the cell. Tests: compat.rs skill_config_dirs gating, a HOME-pinned test proving ~/.agents is scanned by default and dropped when the cell is off (both fail against the unconditional scan), and an env/TOML resolution test in fuigo-shell. fuigo inspect reports the new cell (14 runtime cells). Docs updated (05-configuration, 08-skills, 26-config-reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvuJEwapJMLSJ7BCaSbeuW