### PR TITLE
Fuigo 1.0.16: compat switch for the ~/.agents/skills scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "fuigo-version"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "semver",
 ]

--- a/crates/codegen/fuigo-pager/npm/fuigo-darwin-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/darwin-arm64",
-    "version": "1.0.15",
+    "version": "1.0.16",
     "description": "darwin-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-darwin-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/darwin-x64",
-    "version": "1.0.15",
+    "version": "1.0.16",
     "description": "darwin-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-linux-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/linux-arm64",
-    "version": "1.0.15",
+    "version": "1.0.16",
     "description": "linux-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-linux-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/linux-x64",
-    "version": "1.0.15",
+    "version": "1.0.16",
     "description": "linux-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-win32-arm64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/win32-arm64",
-    "version": "1.0.15",
+    "version": "1.0.16",
     "description": "win32-arm64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo-win32-x64/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fuigo/win32-x64",
-    "version": "1.0.15",
+    "version": "1.0.16",
     "description": "win32-x64 binary for fuigo. Do not install directly; install fuigo instead.",
     "license": "Apache-2.0",
     "files": [

--- a/crates/codegen/fuigo-pager/npm/fuigo/package.json
+++ b/crates/codegen/fuigo-pager/npm/fuigo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fuigo",
-    "version": "1.0.15",
+    "version": "1.0.16",
     "description": "Bring Fuigo into your terminal",
     "license": "Apache-2.0",
     "bin": {
@@ -40,11 +40,11 @@
         "@iarna/toml": "^3.0.0"
     },
     "optionalDependencies": {
-        "@fuigo/darwin-arm64": "1.0.15",
-        "@fuigo/darwin-x64": "1.0.15",
-        "@fuigo/linux-arm64": "1.0.15",
-        "@fuigo/linux-x64": "1.0.15",
-        "@fuigo/win32-arm64": "1.0.15",
-        "@fuigo/win32-x64": "1.0.15"
+        "@fuigo/darwin-arm64": "1.0.16",
+        "@fuigo/darwin-x64": "1.0.16",
+        "@fuigo/linux-arm64": "1.0.16",
+        "@fuigo/linux-x64": "1.0.16",
+        "@fuigo/win32-arm64": "1.0.16",
+        "@fuigo/win32-x64": "1.0.16"
     }
 }

--- a/crates/codegen/fuigo-version/Cargo.toml
+++ b/crates/codegen/fuigo-version/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 license = "Apache-2.0"
 name = "fuigo-version"
-version = "1.0.15"
+version = "1.0.16"
 edition.workspace = true
 description = "Lockstepped fuigo CLI version."
 


### PR DESCRIPTION
Version bump to 1.0.16 (fuigo-version crate, Cargo.lock entry, the seven npm package manifests).

Ships #16, which resolves #15: a compat switch for the vendor-neutral ~/.agents/skills scan (FUIGO_AGENTS_SKILLS_ENABLED / [compat.agents] skills, default ON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvuJEwapJMLSJ7BCaSbeuW